### PR TITLE
Change of vterm handling logic on backend chardev input event

### DIFF
--- a/lunaix-os/hal/char/LBuild
+++ b/lunaix-os/hal/char/LBuild
@@ -4,5 +4,7 @@ sources([
     "devnull.c",
     "serial.c",
     "devzero.c",
-    "lxconsole.c",
 ])
+
+if config("vga_console"):
+    sources("lxconsole.c")

--- a/lunaix-os/hal/char/LConfig
+++ b/lunaix-os/hal/char/LConfig
@@ -5,3 +5,10 @@ def char_device():
     """ Controlling support of character devices """
 
     add_to_collection(hal)
+
+    @Term
+    def vga_console():
+        """ Enable VGA console device (text mode only) """
+
+        type(bool)
+        default(True)

--- a/lunaix-os/hal/char/devzero.c
+++ b/lunaix-os/hal/char/devzero.c
@@ -6,14 +6,14 @@
 static int
 __zero_rd_pg(struct device* dev, void* buf, size_t offset)
 {
-    memset(&((u8_t*)buf)[offset], 0, PAGE_SIZE);
+    memset(buf, 0, PAGE_SIZE);
     return PAGE_SIZE;
 }
 
 static int
 __zero_rd(struct device* dev, void* buf, size_t offset, size_t len)
 {
-    memset(&((u8_t*)buf)[offset], 0, len);
+    memset(buf, 0, len);
     return len;
 }
 

--- a/lunaix-os/hal/char/lxconsole.c
+++ b/lunaix-os/hal/char/lxconsole.c
@@ -27,6 +27,7 @@
 
 struct console
 {
+    struct capability_meta* tp_cap;
     struct lx_timer* flush_timer;
     struct fifo_buf output;
     struct fifo_buf input;
@@ -90,8 +91,12 @@ __lxconsole_listener(struct input_device* dev)
     }
 
     fifo_putone(&lx_console.input, ttychr);
-    pwake_all(&lx_reader);
 
+    struct termport_capability* tpcap;
+    tpcap = get_capability(lx_console.tp_cap, typeof(*tpcap));
+    term_notify_data_avaliable(tpcap);
+    
+    pwake_all(&lx_reader);
 done:
     return INPUT_EVT_NEXT;
 }
@@ -130,6 +135,14 @@ __tty_read(struct device* dev, void* buf, size_t offset, size_t len)
     pwait(&lx_reader);
 
     return count + fifo_read(&console->input, buf + count, len - count);
+}
+
+int
+__tty_read_async(struct device* dev, void* buf, size_t offset, size_t len)
+{
+    struct console* console = (struct console*)dev->underlay;
+
+    return fifo_read(&console->input, buf, len);
 }
 
 size_t
@@ -279,13 +292,23 @@ lxconsole_spawn_ttydev(struct device_def* devdef)
     tty_dev->ops.write_page = __tty_write_pg;
     tty_dev->ops.read = __tty_read;
     tty_dev->ops.read_page = __tty_read_pg;
+    tty_dev->ops.write_async = __tty_write;
+    tty_dev->ops.read_async = __tty_read_async;
 
     waitq_init(&lx_reader);
     input_add_listener(__lxconsole_listener);
 
+    struct termport_capability* tp_cap;
+
+    tp_cap = new_capability(TERMPORT_CAP, struct termport_capability);
+    term_cap_set_operations(tp_cap, termport_default_ops);
+    
+    lx_console.tp_cap = cap_meta(tp_cap);
+    device_grant_capability(tty_dev, lx_console.tp_cap);
+
     register_device(tty_dev, &devdef->class, "vcon");
 
-    term_create(tty_dev, "FB");
+    term_create(tty_dev, "VCON");
 
     return 0;
 }

--- a/lunaix-os/hal/char/lxconsole.c
+++ b/lunaix-os/hal/char/lxconsole.c
@@ -318,5 +318,4 @@ static struct device_def lxconsole_def = {
     .class = DEVCLASS(DEVIF_NON, DEVFN_TTY, DEV_BUILTIN),
     .init = lxconsole_spawn_ttydev
 };
-// FIXME
 EXPORT_DEVICE(lxconsole, &lxconsole_def, load_onboot);

--- a/lunaix-os/hal/char/serial.c
+++ b/lunaix-os/hal/char/serial.c
@@ -227,7 +227,18 @@ __serial_set_speed(struct device* dev, speed_t speed)
     struct serial_dev* sdev = serial_device(dev);
     lock_sdev(sdev);
 
-    sdev_execmd(sdev, SERIO_SETBRDIV, speed);
+    sdev_execmd(sdev, SERIO_SETBRDRATE, speed);
+
+    unlock_sdev(sdev);
+}
+
+static void
+__serial_set_baseclk(struct device* dev, unsigned int base)
+{
+    struct serial_dev* sdev = serial_device(dev);
+    lock_sdev(sdev);
+
+    sdev_execmd(sdev, SERIO_SETBRDBASE, base);
 
     unlock_sdev(sdev);
 }
@@ -247,13 +258,14 @@ __serial_set_cntrl_mode(struct device* dev, tcflag_t cflag)
 
 static struct termport_cap_ops tpcap_ops = {
     .set_cntrl_mode = __serial_set_cntrl_mode,
+    .set_clkbase = __serial_set_baseclk,
     .set_speed = __serial_set_speed
 };
 
 struct serial_dev*
 serial_create(struct devclass* class, char* if_ident)
 {
-    struct serial_dev* sdev = valloc(sizeof(struct serial_dev));
+    struct serial_dev* sdev = vzalloc(sizeof(struct serial_dev));
     struct device* dev = device_allocseq(dev_meta(serial_cat), sdev);
     dev->ops.read = __serial_read;
     dev->ops.read_page = __serial_read_page;

--- a/lunaix-os/hal/char/uart/16x50.h
+++ b/lunaix-os/hal/char/uart/16x50.h
@@ -69,6 +69,7 @@ struct uart16550
     struct llist_header local_ports;
     struct serial_dev* sdev;
     ptr_t base_addr;
+    unsigned int base_clk;
     int iv;
 
     struct
@@ -118,12 +119,12 @@ void
 uart_free(struct uart16550*);
 
 static inline int
-uart_baud_divisor(struct uart16550* uart, int div)
+uart_baud_divisor(struct uart16550* uart, unsigned int div)
 {
     u32_t rlc = uart->read_reg(uart, UART_rLC);
 
     uart->write_reg(uart, UART_rLC, UART_rLC_DLAB | rlc);
-    u8_t ls = (div & 0xff), ms = (div & 0xff00) >> 8;
+    u8_t ls = (div & 0x00ff), ms = (div & 0xff00) >> 8;
 
     uart->write_reg(uart, UART_rLS, ls);
     uart->write_reg(uart, UART_rMS, ms);

--- a/lunaix-os/hal/char/uart/16x50_base.c
+++ b/lunaix-os/hal/char/uart/16x50_base.c
@@ -16,6 +16,7 @@ uart_alloc(ptr_t base_addr)
     uart->cntl_save.rie = 0;
 
     uart->base_addr = base_addr;
+    uart->base_clk  = 115200U;
     return uart;
 }
 
@@ -69,9 +70,29 @@ uart_general_exec_cmd(struct serial_dev* sdev, u32_t req, va_list args)
         case SERIO_RXDA:
             uart_clrie(uart);
             break;
-        case SERIO_SETBRDIV:
-            // TODO
-            break;
+        case SERIO_SETBRDRATE:
+            {
+                unsigned int div, rate;
+
+                rate = va_arg(args, speed_t);
+                if (!rate) {
+                    return EINVAL;
+                }
+
+                div  = uart->base_clk / va_arg(args, speed_t);
+                uart_baud_divisor(uart, div);
+                break;
+            }
+        case SERIO_SETBRDBASE:
+            {
+                int clk = va_arg(args, unsigned int);
+                if (!clk) {
+                    return EINVAL;
+                }
+                
+                uart->base_clk = clk;
+                break;
+            }
         case SERIO_SETCNTRLMODE:
             uart_set_control_mode(uart, va_arg(args, tcflag_t));
             break;

--- a/lunaix-os/hal/gfxa/vga/LBuild
+++ b/lunaix-os/hal/gfxa/vga/LBuild
@@ -3,5 +3,6 @@ sources([
     "vga_gfxm_ops.c",
     "vga.c",
     "vga_mmio_ops.c",
-    "vga_pci.c"
+    "vga_pci.c",
+    "vga_rawtty.c",
 ])

--- a/lunaix-os/hal/gfxa/vga/vga_rawtty.c
+++ b/lunaix-os/hal/gfxa/vga/vga_rawtty.c
@@ -2,6 +2,9 @@
 #include <lunaix/spike.h>
 #include <lunaix/tty/tty.h>
 #include <stdint.h>
+#include <lunaix/owloysius.h>
+#include <lunaix/mm/pagetable.h>
+#include <lunaix/mm/mmio.h>
 
 #include <sys/port_io.h>
 
@@ -114,3 +117,12 @@ tty_put_str_at(char* str, int x, int y)
         str++;
     }
 }
+
+static void
+vga_rawtty_init()
+{
+    // FIXME we should get rid of it at some point
+    tty_init((void*)ioremap(0xB8000, PAGE_SIZE));
+    tty_set_theme(VGA_COLOR_WHITE, VGA_COLOR_BLACK);
+}
+owloysius_fetch_init(vga_rawtty_init, on_earlyboot);

--- a/lunaix-os/hal/term/LBuild
+++ b/lunaix-os/hal/term/LBuild
@@ -2,6 +2,7 @@ sources([
     "term.c",
     "console.c",
     "term_io.c",
+    "default_ops.c",
     "lcntls/ansi_cntl.c",
     "lcntls/lcntl.c",
 ])

--- a/lunaix-os/hal/term/default_ops.c
+++ b/lunaix-os/hal/term/default_ops.c
@@ -1,0 +1,25 @@
+#include <hal/term.h>
+
+static void
+__tpcap_default_set_speed(struct device* dev, speed_t speed)
+{
+    
+}
+
+static void
+__tpcap_default_set_baseclk(struct device* dev, unsigned int base)
+{
+    
+}
+
+static void
+__tpcap_default_set_cntrl_mode(struct device* dev, tcflag_t cflag)
+{
+    
+}
+
+struct termport_cap_ops default_termport_cap_ops = {
+    .set_cntrl_mode = __tpcap_default_set_cntrl_mode,
+    .set_clkbase = __tpcap_default_set_baseclk,
+    .set_speed = __tpcap_default_set_speed
+};

--- a/lunaix-os/hal/term/lcntls/ansi_cntl.c
+++ b/lunaix-os/hal/term/lcntls/ansi_cntl.c
@@ -9,25 +9,18 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include <hal/term.h>
+#include "lcntl.h"
 #include <usr/lunaix/term.h>
 
 #define CTRL_MNEMO(chr) (chr - 'A' + 1)
 
-static inline int
-__ansi_actcontrol(struct term* termdev, struct linebuffer* lbuf, char chr)
+int
+__ansi_actcontrol(struct lcntl_state* state, char chr)
 {
-    struct rbuffer* cooked = lbuf->next;
-    switch (chr) {
-        default:
-            if ((int)chr < 32) {
-                rbuffer_put(cooked, '^');
-                return rbuffer_put(cooked, chr += 64);
-            }
-            break;
+    if (chr < 32 && chr != '\n') {
+        lcntl_put_char(state, '^');
+        return lcntl_put_char(state, chr += 64);
     }
 
-    return rbuffer_put_nof(cooked, chr);
+    return lcntl_put_char(state, chr);
 }
-
-struct term_lcntl ansi_line_controller = {.process_and_put = __ansi_actcontrol};

--- a/lunaix-os/hal/term/lcntls/lcntl.c
+++ b/lunaix-os/hal/term/lcntls/lcntl.c
@@ -58,7 +58,7 @@ lcntl_transform_seq(struct term* tdev, struct linebuffer* lbuf, bool out)
         }
     }
 
-    while (allow_more && rbuffer_get(raw, &c)) {
+    while (rbuffer_get(raw, &c)) {
 
         if (c == '\r' && ((_if & _ICRNL) || (_of & _OCRNL))) {
             c = '\n';
@@ -147,6 +147,10 @@ lcntl_transform_seq(struct term* tdev, struct linebuffer* lbuf, bool out)
         }
 
     put_char:
+        if (!allow_more) {
+            continue;
+        }
+
         if (!out && (_lf & _IEXTEN) && lcntl_slave_put) {
             allow_more = lcntl_slave_put(tdev, lbuf, c);
         } else {

--- a/lunaix-os/hal/term/lcntls/lcntl.h
+++ b/lunaix-os/hal/term/lcntls/lcntl.h
@@ -1,0 +1,77 @@
+#ifndef __LUNAIX_LCNTL_H
+#define __LUNAIX_LCNTL_H
+
+#include <hal/term.h>
+
+#define LCNTLF_SPECIAL_CHAR      0b000001
+#define LCNTLF_CLEAR_INBUF       0b000010
+#define LCNTLF_CLEAR_OUTBUF      0b000100
+#define LCNTLF_STOP              0b001000
+
+enum lcntl_dir {
+    INBOUND,
+    OUTBOUND
+};
+
+struct lcntl_state {
+    struct term* tdev;
+    tcflag_t _if;   // iflags
+    tcflag_t _of;   // oflags
+    tcflag_t _lf;   // local flags
+    tcflag_t _cf;   // control flags
+    tcflag_t _sf;   // state flags
+    enum lcntl_dir direction;
+
+    struct linebuffer* active_line;
+    struct rbuffer* inbuf;
+    struct rbuffer* outbuf;
+    struct rbuffer* echobuf;
+};
+
+int  
+lcntl_put_char(struct lcntl_state* state, char c);
+
+static inline void
+lcntl_set_flag(struct lcntl_state* state, int flags)
+{
+    state->_sf |= flags;
+}
+
+static inline void
+lcntl_raise_line_event(struct lcntl_state* state, int event)
+{
+    state->active_line->sflags |= event;
+}
+
+static inline void
+lcntl_unset_flag(struct lcntl_state* state, int flags)
+{
+    state->_sf &= ~flags;
+}
+
+static inline bool
+lcntl_test_flag(struct lcntl_state* state, int flags)
+{
+    return !!(state->_sf & flags);
+}
+
+static inline bool
+lcntl_outbound(struct lcntl_state* state)
+{
+    return (state->direction == OUTBOUND);
+}
+
+static inline bool
+lcntl_inbound(struct lcntl_state* state)
+{
+    return (state->direction == INBOUND);
+}
+
+static inline bool
+lcntl_check_echo(struct lcntl_state* state, int echo_type)
+{
+    return lcntl_inbound(state) && (state->_lf & echo_type);
+}
+
+
+#endif /* __LUNAIX_LCNTL_H */

--- a/lunaix-os/hal/term/term.c
+++ b/lunaix-os/hal/term/term.c
@@ -148,15 +148,12 @@ tdev_do_read(struct device* dev, void* buf, off_t fpos, size_t len)
     size_t rdsz = 0;
 
     while (cont && rdsz < len) {
-        if (rbuffer_empty(deref(current))) {
-            tdev->line_in.sflags = 0;
-            cont = term_read(tdev);
-        }
-
+        cont = term_read(tdev);
         rdsz += rbuffer_gets(
             deref(current), &((char*)buf)[rdsz], len - rdsz);
     }
-
+    
+    tdev->line_in.sflags = 0;
     return rdsz;
 }
 

--- a/lunaix-os/hal/term/term.c
+++ b/lunaix-os/hal/term/term.c
@@ -172,6 +172,7 @@ load_default_setting(struct term* tdev)
     tdev->lflags = _ICANON | _IEXTEN | _ISIG | _ECHO | _ECHOE | _ECHONL;
     tdev->iflags = _ICRNL | _IGNBRK;
     tdev->oflags = _ONLCR | _OPOST;
+    tdev->iospeed = _B9600;
     memcpy(tdev->cc, default_cc, _NCCS * sizeof(cc_t));
 }
 

--- a/lunaix-os/hal/term/term.c
+++ b/lunaix-os/hal/term/term.c
@@ -8,12 +8,8 @@
 
 #include <usr/lunaix/ioctl_defs.h>
 
-#define ANSI_LCNTL 0
 #define termdev(dev) ((struct term*)(dev)->underlay)
 
-extern struct term_lcntl ansi_line_controller;
-static struct term_lcntl* line_controls[] = {[ANSI_LCNTL] =
-                                                 &ansi_line_controller};
 #define LCNTL_TABLE_LEN (sizeof(line_controls) / sizeof(struct term_lcntl*))
 
 static struct devclass termdev_class = DEVCLASS(DEVIF_NON, DEVFN_TTY, DEV_VTERM);
@@ -206,9 +202,6 @@ term_create(struct device* chardev, char* suffix)
     tdev->ops.exec_cmd = term_exec_cmd;
 
     waitq_init(&terminal->line_in_event);
-
-    // TODO choice of lcntl can be flexible
-    terminal->lcntl = line_controls[ANSI_LCNTL];
 
     alloc_term_buffer(terminal, 1024);
 

--- a/lunaix-os/hal/term/term.c
+++ b/lunaix-os/hal/term/term.c
@@ -16,7 +16,7 @@ static struct term_lcntl* line_controls[] = {[ANSI_LCNTL] =
                                                  &ansi_line_controller};
 #define LCNTL_TABLE_LEN (sizeof(line_controls) / sizeof(struct term_lcntl*))
 
-static struct devclass termdev = DEVCLASS(DEVIF_NON, DEVFN_TTY, DEV_VTERM);
+static struct devclass termdev_class = DEVCLASS(DEVIF_NON, DEVFN_TTY, DEV_VTERM);
 
 struct device* sysconsole = NULL;
 
@@ -85,7 +85,9 @@ term_exec_cmd(struct device* dev, u32_t req, va_list args)
             tios->c_baud = term->iospeed;
         } break;
         case TDEV_TCSETATTR: {
+            struct termport_cap_ops* cap_ops;
             struct termios* tios = va_arg(args, struct termios*);
+
             term->iflags = tios->c_iflag;
             term->oflags = tios->c_oflag;
             term->lflags = tios->c_lflag;
@@ -98,14 +100,16 @@ term_exec_cmd(struct device* dev, u32_t req, va_list args)
                 goto done;
             }
 
+            cap_ops = term->tp_cap->cap_ops;
+
             if (tios->c_baud != term->iospeed) {
                 term->iospeed = tios->c_baud;
 
-                term->tp_cap->set_speed(term->chdev, tios->c_baud);
+                cap_ops->set_speed(term->chdev, tios->c_baud);
             }
 
             if (old_cf != tios->c_cflag) {
-                term->tp_cap->set_cntrl_mode(term->chdev, tios->c_cflag);
+                cap_ops->set_cntrl_mode(term->chdev, tios->c_cflag);
             }
         } break;
         default:
@@ -146,6 +150,7 @@ tdev_do_read(struct device* dev, void* buf, off_t fpos, size_t len)
     lbuf_ref_t current = ref_current(&tdev->line_in);
     bool cont = true;
     size_t rdsz = 0;
+
     while (cont && rdsz < len) {
         if (rbuffer_empty(deref(current))) {
             tdev->line_in.sflags = 0;
@@ -181,18 +186,25 @@ alloc_term_buffer(struct term* terminal, size_t sz_hlf)
 struct term*
 term_create(struct device* chardev, char* suffix)
 {
-    struct term* terminal = vzalloc(sizeof(struct term));
+    struct term* terminal;
+    struct device* tdev;
+    struct capability_meta* termport_cap;
+    struct capability_meta* tios_cap;
 
+    terminal = vzalloc(sizeof(struct term));
     if (!terminal) {
         return NULL;
     }
 
-    terminal->dev = device_allocseq(NULL, terminal);
+    tdev = device_allocseq(NULL, terminal);
+    terminal->dev = tdev;
     terminal->chdev = chardev;
 
-    terminal->dev->ops.read = tdev_do_read;
-    terminal->dev->ops.write = tdev_do_write;
-    terminal->dev->ops.exec_cmd = term_exec_cmd;
+    tdev->ops.read = tdev_do_read;
+    tdev->ops.write = tdev_do_write;
+    tdev->ops.exec_cmd = term_exec_cmd;
+
+    waitq_init(&terminal->line_in_event);
 
     // TODO choice of lcntl can be flexible
     terminal->lcntl = line_controls[ANSI_LCNTL];
@@ -201,18 +213,22 @@ term_create(struct device* chardev, char* suffix)
 
     if (chardev) {
         int cdev_var = DEV_VAR_FROM(chardev->ident.unique);
-        register_device(terminal->dev, &termdev, "tty%s%d", suffix, cdev_var);
+        register_device(tdev, &termdev_class, "tty%s%d", suffix, cdev_var);
     } else {
-        register_device(terminal->dev, &termdev, "tty%d", termdev.variant++);
+        register_device(tdev, &termdev_class, "tty%d", termdev_class.variant++);
     }
 
-    struct capability_meta* termport_cap = device_get_capability(chardev, TERMPORT_CAP);
+    termport_cap = device_get_capability(chardev, TERMPORT_CAP);
     if (termport_cap) {
-        terminal->tp_cap = get_capability(termport_cap, struct termport_capability);
+        terminal->tp_cap = 
+            get_capability(termport_cap, struct termport_capability);
+        
+        assert(terminal->tp_cap->cap_ops);
+        terminal->tp_cap->term = terminal;
     }
 
-    struct capability_meta* term_cap = new_capability_marker(TERMIOS_CAP);
-    device_grant_capability(terminal->dev, term_cap);
+    tios_cap = new_capability_marker(TERMIOS_CAP);
+    device_grant_capability(tdev, tios_cap);
 
     load_default_setting(terminal);
 
@@ -253,6 +269,6 @@ void
 term_sendsig(struct term* tdev, int signal)
 {
     if ((tdev->lflags & _ISIG)) {
-        proc_setsignal(get_process(tdev->fggrp), signal);
+        signal_send(-tdev->fggrp, signal);
     }
 }

--- a/lunaix-os/hal/term/term_io.c
+++ b/lunaix-os/hal/term/term_io.c
@@ -11,49 +11,29 @@
 static int
 do_read_raw(struct term* tdev)
 {
-    struct device* chdev = tdev->chdev;
+    struct linebuffer* line_in;
+    lbuf_ref_t current_buf;
+    size_t min, sz = 0;
+    time_t t, expr, dt = 0;
+    
+    line_in = &tdev->line_in;
+    current_buf = ref_current(line_in);
 
-    struct linebuffer* line_in = &tdev->line_in;
-    size_t max_lb_sz = line_in->sz_hlf;
+    min = tdev->cc[_VMIN] - 1;
+    t = clock_systime();
+    expr = (tdev->cc[_VTIME] * 100) - 1;
 
-    line_flip(line_in);
-
-    char* inbuffer = line_in->current->buffer;
-    size_t min = tdev->cc[_VMIN] - 1;
-    size_t sz = chdev->ops.read_async(chdev, inbuffer, 0, max_lb_sz);
-    time_t t = clock_systime(), dt = 0;
-    time_t expr = (tdev->cc[_VTIME] * 100) - 1;
-
+    min = MIN(min, (size_t)line_in->sz_hlf);
     while (sz <= min && dt <= expr) {
         // XXX should we held the device lock while we are waiting?
         sched_pass();
         dt = clock_systime() - t;
         t += dt;
 
-        max_lb_sz -= sz;
-
-        // TODO pass a flags to read to indicate it is non blocking ops
-        sz += chdev->ops.read_async(chdev, &inbuffer[sz], 0, max_lb_sz);
+        sz = deref(current_buf)->len;
     }
 
-    rbuffer_puts(line_in->next, inbuffer, sz);
-    line_flip(line_in);
-
     return 0;
-}
-
-static int
-do_read_raw_canno(struct term* tdev)
-{
-    struct device* chdev = tdev->chdev;
-    struct linebuffer* line_in = &tdev->line_in;
-    struct rbuffer* current_buf = line_in->current;
-    int sz = chdev->ops.read(chdev, current_buf->buffer, 0, line_in->sz_hlf);
-
-    current_buf->ptr = sz;
-    current_buf->len = sz;
-
-    return sz;
 }
 
 static int
@@ -66,16 +46,11 @@ term_read_noncano(struct term* tdev)
 static int
 term_read_cano(struct term* tdev)
 {
-    struct device* chdev = tdev->chdev;
-    struct linebuffer* line_in = &tdev->line_in;
-    int size = 0;
+    struct linebuffer* line_in;
 
+    line_in = &tdev->line_in;
     while (!(line_in->sflags & ONSTOP)) {
-        // move all hold-out content to 'next' buffer
-        line_flip(line_in);
-
-        size += do_read_raw_canno(tdev);
-        lcntl_transform_inseq(tdev);
+        pwait(&tdev->line_in_event);
     }
 
     return 0;
@@ -87,6 +62,7 @@ term_read(struct term* tdev)
     if ((tdev->lflags & _ICANON)) {
         return term_read_cano(tdev);
     }
+
     return term_read_noncano(tdev);
 }
 
@@ -124,4 +100,33 @@ term_flush(struct term* tdev)
     }
 
     return count;
+}
+
+void
+term_notify_data_avaliable(struct termport_capability* cap)
+{
+    struct term* term;
+    struct device* term_chrdev;
+    struct linebuffer* line_in;
+    char* buf;
+    int sz;
+
+    term = cap->term;
+    term_chrdev = term->chdev;
+    line_in = &term->line_in;
+    
+    // make room for current buf
+    line_flip(line_in);
+    buf = line_in->current->buffer;
+
+    sz = term_chrdev->ops.read_async(term_chrdev, buf, 0, line_in->sz_hlf);
+    line_in->current->ptr = sz;
+    line_in->current->len = sz;
+
+    if ((term->lflags & _ICANON)) {
+        lcntl_transform_inseq(term);
+        // write all processed to next, and flip back to current
+    }
+
+    pwake_all(&term->line_in_event);
 }

--- a/lunaix-os/hal/term/term_io.c
+++ b/lunaix-os/hal/term/term_io.c
@@ -5,8 +5,8 @@
 
 #include <usr/lunaix/term.h>
 
-#define ONBREAK (LSTATE_EOF | LSTATE_SIGRAISE)
-#define ONSTOP (LSTATE_SIGRAISE | LSTATE_EOL | LSTATE_EOF)
+#define ONBREAK (LEVT_EOF | LEVT_SIGRAISE)
+#define ONSTOP (LEVT_SIGRAISE | LEVT_EOL | LEVT_EOF)
 
 static int
 do_read_raw(struct term* tdev)

--- a/lunaix-os/includes/hal/serial.h
+++ b/lunaix-os/includes/hal/serial.h
@@ -33,6 +33,8 @@ struct serial_dev
     struct rbuffer rxbuf;
     int wr_len;
 
+    struct capability_meta* tp_cap;
+
     /**
      * @brief Write buffer to TX. The return code indicate
      * the transaction is either done in synced mode (TX_DONE) or will be

--- a/lunaix-os/includes/hal/term.h
+++ b/lunaix-os/includes/hal/term.h
@@ -17,20 +17,14 @@ struct linebuffer
     short sflags;
     short sz_hlf;
 };
-#define LSTATE_EOL (1)
-#define LSTATE_EOF (1 << 1)
-#define LSTATE_SIGRAISE (1 << 2)
+#define LEVT_EOL (1)
+#define LEVT_EOF (1 << 1)
+#define LEVT_SIGRAISE (1 << 2)
 
 typedef struct rbuffer** lbuf_ref_t;
 #define ref_current(lbuf) (&(lbuf)->current)
 #define ref_next(lbuf) (&(lbuf)->next)
 #define deref(bref) (*(bref))
-
-struct term_lcntl
-{
-    struct term* term;
-    int (*process_and_put)(struct term*, struct linebuffer*, char);
-};
 
 /**
  * @brief Communication port capability that a device is supported natively, 
@@ -67,7 +61,6 @@ struct term
 {
     struct device* dev;
     struct device* chdev;
-    struct term_lcntl* lcntl;
     struct linebuffer line_out;
     struct linebuffer line_in;
     char* scratch_pad;
@@ -82,8 +75,11 @@ struct term
     tcflag_t lflags;
     tcflag_t cflags;
     cc_t cc[_NCCS];
+
+    /* -- END POSIX.1-2008 compliant fields -- */
     speed_t iospeed;
     speed_t clkbase;
+    tcflag_t tflags;    // temp flags
 };
 
 extern struct device* sysconsole;
@@ -93,15 +89,6 @@ term_create(struct device* chardev, char* suffix);
 
 int
 term_bind(struct term* tdev, struct device* chdev);
-
-int
-term_push_lcntl(struct term* tdev, struct term_lcntl* lcntl);
-
-int
-term_pop_lcntl(struct term* tdev);
-
-struct term_lcntl*
-term_get_lcntl(u32_t lcntl_index);
 
 static inline void
 line_flip(struct linebuffer* lbf)

--- a/lunaix-os/includes/hal/term.h
+++ b/lunaix-os/includes/hal/term.h
@@ -129,4 +129,10 @@ term_cap_set_operations(struct termport_capability* cap,
 void
 term_notify_data_avaliable(struct termport_capability* cap);
 
+#define termport_default_ops                                    \
+    ({                                                          \
+        extern struct termport_cap_ops default_termport_cap_ops;\
+        &default_termport_cap_ops;                              \
+    })
+
 #endif /* __LUNAIX_TERM_H */

--- a/lunaix-os/includes/hal/term.h
+++ b/lunaix-os/includes/hal/term.h
@@ -52,6 +52,7 @@ struct term;
 struct termport_cap_ops
 {
     void (*set_speed)(struct device*, speed_t);
+    void (*set_clkbase)(struct device*, unsigned int);
     void (*set_cntrl_mode)(struct device*, tcflag_t);
 };
 
@@ -82,6 +83,7 @@ struct term
     tcflag_t cflags;
     cc_t cc[_NCCS];
     speed_t iospeed;
+    speed_t clkbase;
 };
 
 extern struct device* sysconsole;

--- a/lunaix-os/includes/lunaix/ds/rbuffer.h
+++ b/lunaix-os/includes/lunaix/ds/rbuffer.h
@@ -30,11 +30,22 @@ int
 rbuffer_puts(struct rbuffer* rb, char* c, size_t len);
 
 int
-rbuffer_gets(struct rbuffer* rb, char* buf, size_t len);
+rbuffer_gets_opt(struct rbuffer* rb, char* buf, size_t len, bool consumed);
 
 int
 rbuffer_get(struct rbuffer* rb, char* c);
 
+static inline int
+rbuffer_gets(struct rbuffer* rb, char* buf, size_t len)
+{
+    return rbuffer_gets_opt(rb, buf, len, true);
+}
+
+static inline int
+rbuffer_gets_no_consume(struct rbuffer* rb, char* buf, size_t len)
+{
+    return rbuffer_gets_opt(rb, buf, len, false);
+}
 
 static inline void
 rbuffer_clear(struct rbuffer* rb)
@@ -46,6 +57,19 @@ static inline bool
 rbuffer_empty(struct rbuffer* rb)
 {
     return rb->len == 0;
+}
+
+static inline unsigned int
+rbuffer_len(struct rbuffer* rb)
+{
+    return rb->len;
+}
+
+static inline void
+rbuffer_setcontent(struct rbuffer* rb, size_t content_len)
+{
+    rb->ptr = content_len;
+    rb->len = content_len;
 }
 
 static inline bool

--- a/lunaix-os/includes/usr/lunaix/serial.h
+++ b/lunaix-os/includes/usr/lunaix/serial.h
@@ -3,13 +3,14 @@
 
 #include "ioctl_defs.h"
 
-#define SERIO_RXEN IOREQ(1, 0)
-#define SERIO_RXDA IOREQ(2, 0)
+#define SERIO_RXEN          IOREQ(1, 0)
+#define SERIO_RXDA          IOREQ(2, 0)
 
-#define SERIO_TXEN IOREQ(3, 0)
-#define SERIO_TXDA IOREQ(4, 0)
+#define SERIO_TXEN          IOREQ(3, 0)
+#define SERIO_TXDA          IOREQ(4, 0)
 
-#define SERIO_SETBRDIV IOREQ(5, 0)
-#define SERIO_SETCNTRLMODE IOREQ(6, 0)
+#define SERIO_SETBRDRATE    IOREQ(5, 0)
+#define SERIO_SETCNTRLMODE  IOREQ(6, 0)
+#define SERIO_SETBRDBASE    IOREQ(7, 0)
 
 #endif /* __LUNAIX_USERIAL_H */

--- a/lunaix-os/kernel/LBuild
+++ b/lunaix-os/kernel/LBuild
@@ -13,7 +13,6 @@ sources([
     "kinit.c",
     "lunad.c",
     "spike.c",
-    "tty/tty.c",
     "kprint/kp_records.c",
     "kprint/kprintf.c",
     "time/clock.c",

--- a/lunaix-os/kernel/ds/rbuffer.c
+++ b/lunaix-os/kernel/ds/rbuffer.c
@@ -61,7 +61,7 @@ rbuffer_puts(struct rbuffer* rb, char* buf, size_t len)
 }
 
 int
-rbuffer_gets(struct rbuffer* rb, char* buf, size_t len)
+rbuffer_gets_opt(struct rbuffer* rb, char* buf, size_t len, bool consumed)
 {
     if (!len || !rb->len)
         return 0;
@@ -79,7 +79,9 @@ rbuffer_gets(struct rbuffer* rb, char* buf, size_t len)
         memcpy(&buf[-nlen], &rb->buffer[ptr_start], nlen);
     }
 
-    rb->len -= nlen;
+    if (consumed) {
+        rb->len -= nlen;
+    }
 
     return nlen;
 }

--- a/lunaix-os/kernel/kinit.c
+++ b/lunaix-os/kernel/kinit.c
@@ -43,13 +43,8 @@ kernel_bootstrap(struct boot_handoff* bhctx)
     /* Begin kernel bootstrapping sequence */
     boot_begin(bhctx);
 
-    tty_init((void*)ioremap(0xB8000, PAGE_SIZE));
-    
     /* Setup kernel memory layout and services */
     kmem_init(bhctx);
-
-    // FIXME this goes to hal/gfxa
-    tty_set_theme(VGA_COLOR_WHITE, VGA_COLOR_BLACK);
 
     boot_parse_cmdline(bhctx);
 

--- a/lunaix-os/kernel/process/signal.c
+++ b/lunaix-os/kernel/process/signal.c
@@ -147,8 +147,7 @@ int
 signal_send(pid_t pid, signum_t signum)
 {
     if (signum >= _SIG_NUM) {
-        syscall_result(EINVAL);
-        return -1;
+        return EINVAL;
     }
 
     pid_t sender_pid = __current->pid;
@@ -166,8 +165,7 @@ signal_send(pid_t pid, signum_t signum)
     } else {
         // TODO: send to all process.
         //  But I don't want to support it yet.
-        syscall_result(EINVAL);
-        return -1;
+        return EINVAL;
     }
 
 send_grp: ;
@@ -179,8 +177,7 @@ send_grp: ;
 
 send_single:
     if (proc_terminated(proc)) {
-        syscall_result(EINVAL);
-        return -1;
+        return EINVAL;
     }
 
     proc_setsignal(proc, signum);
@@ -358,7 +355,7 @@ __DEFINE_LXSYSCALL(int, pause)
 
 __DEFINE_LXSYSCALL2(int, kill, pid_t, pid, int, signum)
 {
-    return signal_send(pid, signum);
+    return syscall_result(signal_send(pid, signum));
 }
 
 __DEFINE_LXSYSCALL1(int, sigpending, sigset_t, *sigset)

--- a/lunaix-os/usr/init/init.c
+++ b/lunaix-os/usr/init/init.c
@@ -36,6 +36,9 @@ init_termios(int fd) {
     term.c_oflag = ONLCR | OPOST;
     term.c_cflag = CREAD | CLOCAL | CS8 | CPARENB;
     term.c_cc[VERASE] = 0x7f;
+    
+    cfsetispeed(&term, B9600);
+    cfsetospeed(&term, B9600);
 
     check(tcsetattr(fd, 0, &term));
 

--- a/lunaix-os/usr/libc/includes/termios.h
+++ b/lunaix-os/usr/libc/includes/termios.h
@@ -89,12 +89,20 @@ static inline speed_t cfgetospeed(const struct termios* termios) { return termio
 
 static inline int cfsetispeed(struct termios* termios, speed_t baud)
 {
+    if (baud > B38400) {
+        return -1;
+    }
+
     termios->c_baud = baud;
     return 0;
 }
 
 static inline int cfsetospeed(struct termios* termios, speed_t baud)
 {
+    if (baud > B38400) {
+        return -1;
+    }
+
     termios->c_baud = baud;
     return 0;
 }
@@ -109,6 +117,5 @@ static inline int cfsetospeed(struct termios* termios, speed_t baud)
 int     tcgetattr(int, struct termios *);
 int     tcsendbreak(int, int);
 int     tcsetattr(int, int, const struct termios *);
-
 
 #endif /* __LUNAIX_TERMIOS_H */

--- a/lunaix-os/usr/sh/sh.c
+++ b/lunaix-os/usr/sh/sh.c
@@ -132,6 +132,27 @@ sh_exec(const char** argv)
     waitpid(p, NULL, 0);
 }
 
+static char*
+sanity_filter(char* buf)
+{
+    int off = 0, i = 0;
+    char c;
+    do {
+        c = buf[i];
+        
+        if ((32 <= c && c <= 126) || !c) {
+            buf[i - off] = c;
+        }
+        else {
+            off++;
+        }
+
+        i++;
+    } while(c);
+
+    return buf;
+}
+
 void
 sh_loop()
 {
@@ -157,6 +178,7 @@ sh_loop()
         }
 
         buf[sz] = '\0';
+        sanity_filter(buf);
 
         // currently, this shell only support single argument
         if (!parse_cmdline(buf, argv)) {


### PR DESCRIPTION
```
Background:
vterm, virtual terminal, is a Lunaix device abstraction layer 
aims providing POSIX-compliant terminal interfacing for any
kinds of TermPort-awared device (such device must be granted
TERMPORT_CAP capability object). And an interfaced device will
have a device mapping in the format of 'tty%s%d' under devfs,
where %s is a suffix of that device driver's choice and %d is
auto-increment id for differentiation.

Problem:
The previous vterm design on handling the ingressed data from
backend is passive, meaning that only a user initiated read
syscall will cause vterm to monitor the backend buffer and
process the data with line-controller if operating under ICANNO
mode. Which cause foreground process failed to respond control
character such as INT (one raise SIGINT) if one do not read and
poll the interface.

Aims of this Patch:
We restructured the vterm handling logic to be 'proactive'
(from the user prespective, the vterm is handling input data by 
itself, but in reality, it is still passive but relative to the
backend device). By impose convention to the backend device that
one should call `term_notify_data_avaliable` upon data is 
avaliable.

We also propose couple of fixes to other part of system:
1. incorrect signal delivery method to the foreground process 
   group
2. race when parent process get destroyed before child process
   does, causing kernel mem access fault.
3. kernel mem access fault on user address in devzero because of
   misused offset.

```