### PR TITLE
Improvements patch: Kernel preemptions

### DIFF
--- a/lunaix-os/LConfig
+++ b/lunaix-os/LConfig
@@ -31,3 +31,24 @@ def debug_and_testing():
         """
         type(bool)
         default(False)
+
+    @Term("Report on stalled thread")
+    def check_stall():
+        """
+        Check and report on any thread that spend too much time in kernel.
+        """
+
+        type(bool)
+        default(True)
+        
+    @Term("Max kernel time allowance")
+    def stall_timeout():
+        """
+        Set the maximum time (in seconds) spent in kernel before considered
+        to be stalled.
+        """
+
+        type(int)
+        default(10)
+
+        return v(check_stall)

--- a/lunaix-os/LConfig
+++ b/lunaix-os/LConfig
@@ -52,3 +52,17 @@ def debug_and_testing():
         default(10)
 
         return v(check_stall)
+    
+    @Term("Max number of preemptions")
+    def stall_max_preempts():
+        """
+        Set the maximum number of preemptions that a task can take
+        before it is considered to be stucked in some loops.
+
+        Setting it to 0 disable this check
+        """
+
+        type(int)
+        default(0)
+
+        return v(check_stall)

--- a/lunaix-os/arch/x86/exceptions/interrupt32.S
+++ b/lunaix-os/arch/x86/exceptions/interrupt32.S
@@ -20,7 +20,7 @@
 .section .bss
     .align 16
     lo_tmp_stack:
-        .skip 256
+        .skip 1024
     tmp_stack:
 
 /*
@@ -182,7 +182,7 @@
         # is required to prevent corrupt existing stack
         movl $tmp_stack, %esp
 
-        call signal_dispatch    # kernel/signal.c
+        call switch_signposting    # kernel/process/switch.c
 
         movl current_thread, %ebx
         test %eax, %eax         # do we have signal to handle?

--- a/lunaix-os/arch/x86/exceptions/interrupt64.S
+++ b/lunaix-os/arch/x86/exceptions/interrupt64.S
@@ -10,7 +10,7 @@
     tmp_store:
         .skip 8
     lo_tmp_stack:
-        .skip 256
+        .skip 1024
     tmp_stack:
     
 
@@ -160,7 +160,7 @@
         # is required to prevent corrupt existing stack
         movq $tmp_stack, %rsp
 
-        call signal_dispatch    # kernel/signal.c
+        call switch_signposting    # kernel/process/switch.c
 
         movq current_thread, %rbx
         test %rax, %rax         # do we have signal to handle?

--- a/lunaix-os/arch/x86/syscall32.S
+++ b/lunaix-os/arch/x86/syscall32.S
@@ -107,12 +107,11 @@
         pushl   12(%ebx)      /* edx - #3 arg */
         pushl   8(%ebx)       /* ecx - #2 arg */
         pushl   4(%ebx)       /* ebx - #1 arg */
+        pushl    (%eax)
         
-        sti
-        call    *(%eax)
-        cli
+        call    dispatch_syscall
 
-        addl    $20, %esp      /* remove the parameters from stack */
+        addl    $24, %esp      /* remove the parameters from stack */
         
         popl    %ebx
         movl    %eax, (%ebx)    /* save the return value */

--- a/lunaix-os/arch/x86/syscall64.S
+++ b/lunaix-os/arch/x86/syscall64.S
@@ -106,16 +106,14 @@
         ret
 
     1:
-
-        movq    irbx(%rbx), %rdi    /* rbx -> rdi #1 arg */
-        movq    ircx(%rbx), %rsi    /* rcx -> rsi #2 arg */
-        movq    irdx(%rbx), %rdx    /* rdx -> rdx #3 arg */
-        movq    irdi(%rbx), %rcx    /* rdi -> rcx #4 arg */
-        movq    irsi(%rbx), %r8     /* rsi -> r8  #5 arg */
+        movq    (%rax),     %rdi
+        movq    irbx(%rbx), %rsi    /* rbx -> rsi #1 arg */
+        movq    ircx(%rbx), %rdx    /* rcx -> rdx #2 arg */
+        movq    irdx(%rbx), %rcx    /* rdx -> rcx #3 arg */
+        movq    irdi(%rbx), %r8     /* rdi -> r8  #4 arg */
+        movq    irsi(%rbx), %r9     /* rsi -> r9  #5 arg */
         
-        sti
-        call    *(%rax)
-        cli
+        call    dispatch_syscall
         
         movq    %rax, irax(%rbx)    /* save the return value */
         

--- a/lunaix-os/arch/x86/trace.c
+++ b/lunaix-os/arch/x86/trace.c
@@ -41,7 +41,7 @@ trace_dump_state(struct hart_state* hstate)
     trace_log("  rdi=0x%016lx, rsi=0x%016lx",
                 rh->rdi, rh->rsi);
 
-    trace_log("   r8=0x%016lx,  r9=0x%016lx",
+    trace_log("  r08=0x%016lx, r09=0x%016lx",
                 rh->r8, rh->r9);
     trace_log("  r10=0x%016lx, r11=0x%016lx",
                 rh->r10, rh->r11);

--- a/lunaix-os/hal/term/term_io.c
+++ b/lunaix-os/hal/term/term_io.c
@@ -1,7 +1,7 @@
 #include <hal/term.h>
 
 #include <lunaix/clock.h>
-#include <lunaix/sched.h>
+#include <lunaix/kpreempt.h>
 
 #include <usr/lunaix/term.h>
 
@@ -26,7 +26,7 @@ do_read_raw(struct term* tdev)
     min = MIN(min, (size_t)line_in->sz_hlf);
     while (sz <= min && dt <= expr) {
         // XXX should we held the device lock while we are waiting?
-        sched_pass();
+        yield_current();
         dt = clock_systime() - t;
         t += dt;
 

--- a/lunaix-os/includes/lunaix/ds/waitq.h
+++ b/lunaix-os/includes/lunaix/ds/waitq.h
@@ -33,7 +33,13 @@ void
 try_wait();
 
 void
+try_wait_check_stall();
+
+void
 pwait(waitq_t* queue);
+
+void
+pwait_check_stall(waitq_t* queue);
 
 void
 pwake_one(waitq_t* queue);

--- a/lunaix-os/includes/lunaix/kpreempt.h
+++ b/lunaix-os/includes/lunaix/kpreempt.h
@@ -2,6 +2,8 @@
 #define __LUNAIX_KPREEMPT_H
 
 #include <sys/abi.h>
+#include <sys/cpu.h>
+#include <lunaix/process.h>
 
 #define _preemptible \
         __attribute__((section(".kf.preempt"))) no_inline
@@ -15,5 +17,59 @@
                     && _retaddr < (ptr_t)__kf_preempt_end,      \
                    "caller must be kernel preemptible");        \
     } while(0)
+
+static inline void
+set_preemption() 
+{
+    cpu_enable_interrupt();
+}
+
+static inline void
+no_preemption() 
+{
+    cpu_disable_interrupt();
+}
+
+static inline void
+__schedule_away()
+{
+    current_thread->stats.last_reentry = clock_systime();
+    
+    set_preemption();
+    cpu_trap_sched();
+}
+
+/**
+ * @brief preempt the current thread, and yield the remaining
+ *        time slice to other threads.
+ * 
+ *        The current thread is marked as if it is being
+ *        preempted involuntarily by kernel.
+ * 
+ */
+static inline void
+preempt_current()
+{
+    no_preemption();
+    thread_stats_update_kpreempt();
+    __schedule_away();
+}
+
+/**
+ * @brief yield the remaining time slice to other threads.
+ * 
+ *        The current thread is marked as if it is being
+ *        preempted voluntarily by itself.
+ * 
+ */
+static inline void
+yield_current()
+{
+    no_preemption();
+    __schedule_away();
+}
+
+bool
+preempt_check_stalled(struct thread* th);
 
 #endif /* __LUNAIX_KPREEMPT_H */

--- a/lunaix-os/includes/lunaix/sched.h
+++ b/lunaix-os/includes/lunaix/sched.h
@@ -28,9 +28,6 @@ sched_init();
 void noret
 schedule();
 
-void
-sched_pass();
-
 void noret
 run(struct thread* thread);
 

--- a/lunaix-os/includes/lunaix/switch.h
+++ b/lunaix-os/includes/lunaix/switch.h
@@ -26,6 +26,10 @@ struct signpost_result
  *        This function might never return if the decision is made to give up
  *        this switching.
  * 
+ *        NOTE: This function might have side effects, it can only be
+ *         called within the twilight zone of context restore. (after entering
+ *         do_switch and before returning from exception)
+ * 
  * @return ptr_t
  */
 ptr_t
@@ -51,7 +55,6 @@ giveup_switch(struct signpost_result* res)
     res->mode  = SWITCH_MODE_GIVEUP;
     res->stack = 0;
 }
-
 
 #endif
 #endif /* __LUNAIX_SWITCH_H */

--- a/lunaix-os/includes/lunaix/switch.h
+++ b/lunaix-os/includes/lunaix/switch.h
@@ -1,0 +1,57 @@
+#ifndef __LUNAIX_SWITCH_H
+#define __LUNAIX_SWITCH_H
+
+#define SWITCH_MODE_NORMAL   0
+#define SWITCH_MODE_FAST     1
+#define SWITCH_MODE_GIVEUP   2
+
+#ifndef __ASM__
+
+#include <lunaix/types.h>
+
+struct signpost_result
+{
+    int mode;
+    ptr_t stack;
+};
+
+/**
+ * @brief Decide how current thread should perform the context switch
+ *        back to it's previously saved context. 
+ * 
+ *        Return a user stack pointer perform a temporary fast redirected 
+ *        context switch. 
+ *        No redirection is required if such pointer is null.
+ * 
+ *        This function might never return if the decision is made to give up
+ *        this switching.
+ * 
+ * @return ptr_t
+ */
+ptr_t
+switch_signposting();
+
+static inline void
+redirect_switch(struct signpost_result* res, ptr_t stack)
+{
+    res->mode  = SWITCH_MODE_FAST;
+    res->stack = stack;
+}
+
+static inline void
+continue_switch(struct signpost_result* res)
+{
+    res->mode  = SWITCH_MODE_NORMAL;
+    res->stack = 0;
+}
+
+static inline void
+giveup_switch(struct signpost_result* res)
+{
+    res->mode  = SWITCH_MODE_GIVEUP;
+    res->stack = 0;
+}
+
+
+#endif
+#endif /* __LUNAIX_SWITCH_H */

--- a/lunaix-os/includes/lunaix/time.h
+++ b/lunaix-os/includes/lunaix/time.h
@@ -22,6 +22,24 @@ typedef struct
     u8_t second;
 } datetime_t;
 
+static inline ticks_t
+ticks_seconds(unsigned int seconds)
+{
+    return seconds * 1000;
+}
+
+static inline ticks_t
+ticks_minutes(unsigned int min)
+{
+    return ticks_seconds(min * 60);
+}
+
+static inline ticks_t
+ticks_msecs(unsigned int ms)
+{
+    return ms;
+}
+
 static inline time_t
 datetime_tounix(datetime_t* dt)
 {

--- a/lunaix-os/kernel/LBuild
+++ b/lunaix-os/kernel/LBuild
@@ -15,8 +15,9 @@ sources([
     "spike.c",
     "lrud.c",
     "bcache.c",
+    "syscall.c",
     "kprint/kp_records.c",
     "kprint/kprintf.c",
     "time/clock.c",
-    "time/timer.c"
+    "time/timer.c",
 ])

--- a/lunaix-os/kernel/block/blkio.c
+++ b/lunaix-os/kernel/block/blkio.c
@@ -127,12 +127,12 @@ blkio_commit(struct blkio_req* req, int options)
     if (blkio_stalled(ctx)) {
         if ((options & BLKIO_WAIT)) {
             blkio_schedule(ctx);
-            try_wait();
+            try_wait_check_stall();
             return;
         }
         blkio_schedule(ctx);
     } else if ((options & BLKIO_WAIT)) {
-        try_wait();
+        try_wait_check_stall();
     }
 }
 

--- a/lunaix-os/kernel/device/poll.c
+++ b/lunaix-os/kernel/device/poll.c
@@ -7,6 +7,7 @@
 #include <lunaix/spike.h>
 #include <lunaix/syscall.h>
 #include <lunaix/syscall_utils.h>
+#include <lunaix/kpreempt.h>
 
 #define MAX_POLLER_COUNT 16
 
@@ -153,7 +154,7 @@ static void
 __wait_until_event()
 {
     block_current_thread();
-    sched_pass();
+    yield_current();
 }
 
 void

--- a/lunaix-os/kernel/ds/mutex.c
+++ b/lunaix-os/kernel/ds/mutex.c
@@ -1,6 +1,6 @@
 #include <lunaix/ds/mutex.h>
 #include <lunaix/process.h>
-#include <lunaix/sched.h>
+#include <lunaix/kpreempt.h>
 
 static inline bool must_inline
 __mutex_check_owner(mutex_t* mutex)
@@ -12,7 +12,7 @@ static inline void must_inline
 __mutext_lock(mutex_t* mutex)
 {
     while (atomic_load(&mutex->lk)) {
-        sched_pass();
+        preempt_current();
     }
 
     atomic_fetch_add(&mutex->lk, 1);

--- a/lunaix-os/kernel/ds/semaphore.c
+++ b/lunaix-os/kernel/ds/semaphore.c
@@ -1,5 +1,5 @@
 #include <lunaix/ds/semaphore.h>
-#include <lunaix/sched.h>
+#include <lunaix/kpreempt.h>
 
 void
 sem_init(struct sem_t* sem, unsigned int initial)
@@ -12,7 +12,7 @@ sem_wait(struct sem_t* sem)
 {
     while (!atomic_load(&sem->counter)) {
         // FIXME: better thing like wait queue
-        sched_pass();
+        preempt_current();
     }
     atomic_fetch_sub(&sem->counter, 1);
 }

--- a/lunaix-os/kernel/lunad.c
+++ b/lunaix-os/kernel/lunad.c
@@ -58,7 +58,7 @@ fail:
 static void
 lunad_do_usr() {
     // No, these are not preemptive
-    cpu_disable_interrupt();
+    no_preemption();
 
     if (!mount_bootmedium() || !exec_initd()) {
         fail("failed to initd");
@@ -89,11 +89,11 @@ lunad_main()
         thread (which is preemptive!)
     */
 
-    cpu_enable_interrupt();
+    set_preemption();
     while (1)
     {
         cleanup_detached_threads();
-        sched_pass();
+        yield_current();
     }
 }
 

--- a/lunaix-os/kernel/process/LBuild
+++ b/lunaix-os/kernel/process/LBuild
@@ -5,5 +5,7 @@ sources([
     "process.c",
     "taskfs.c",
     "task_attr.c",
-    "thread.c"
+    "thread.c",
+    "preemption.c",
+    "switch.c",
 ])

--- a/lunaix-os/kernel/process/fork.c
+++ b/lunaix-os/kernel/process/fork.c
@@ -8,6 +8,7 @@
 #include <lunaix/syscall.h>
 #include <lunaix/syslog.h>
 #include <lunaix/signal.h>
+#include <lunaix/kpreempt.h>
 
 #include <sys/abi.h>
 #include <sys/mm/mm_defs.h>
@@ -149,7 +150,7 @@ done:
 pid_t
 dup_proc()
 {
-    cpu_disable_interrupt();
+    no_preemption();
     
     struct proc_info* pcb = alloc_process();
     if (!pcb) {

--- a/lunaix-os/kernel/process/preemption.c
+++ b/lunaix-os/kernel/process/preemption.c
@@ -1,0 +1,77 @@
+#include <lunaix/kpreempt.h>
+#include <lunaix/process.h>
+#include <lunaix/switch.h>
+#include <lunaix/syslog.h>
+#include <lunaix/trace.h>
+
+LOG_MODULE("preempt");
+
+#ifdef CONFIG_CHECK_STALL
+bool
+preempt_check_stalled(struct thread* th)
+{
+    // we can't access the hart state here
+    //  as th might be in other address space
+
+    if (thread_flags_test(th, TH_STALLED))
+    {
+        // alrady stalled or marked as never stall, no need to concern
+        return false;
+    }
+
+    if (!th->stats.kpreempt_count) {
+        return false;
+    }
+
+    if (th->stats.at_user) {
+        return false;
+    }
+
+    ticks_t total_elapsed;
+    struct thread_stats* stats;
+
+    stats   = &current_thread->stats;
+
+    total_elapsed = thread_stats_kernel_elapse(th);
+    total_elapsed = total_elapsed * th->stats.kpreempt_count;
+    return total_elapsed > ticks_seconds(CONFIG_STALL_TIMEOUT);
+}
+
+#else 
+bool
+preempt_check_stalled(struct thread* th)
+{
+    return false;
+}
+
+#endif
+
+void
+preempt_handle_stalled(struct signpost_result* result)
+{
+    if (!thread_flags_test(current_thread, TH_STALLED))
+    {
+        continue_switch(result);
+        return;
+    }
+
+    kprintf("+++++ ");
+    kprintf(" stalling detected (pid: %d, tid: %d)", 
+                __current->pid, current_thread->tid);
+    kprintf(" (preempted: %d, elapsed: %dms)", 
+                current_thread->stats.kpreempt_count, 
+                thread_stats_kernel_elapse(current_thread));
+    kprintf("   are you keeping Luna too busy?");
+    kprintf("+++++ ");
+
+    kprintf("last known state:");
+    trace_dump_state(current_thread->hstate);
+
+    kprintf("trace from the point of stalling:");
+    trace_printstack_isr(current_thread->hstate);
+
+    kprintf("thread is blocked");
+
+    block_current_thread();
+    giveup_switch(result);
+}

--- a/lunaix-os/kernel/process/sched.c
+++ b/lunaix-os/kernel/process/sched.c
@@ -228,16 +228,6 @@ done:
     fail("unexpected return from scheduler");
 }
 
-void
-sched_pass()
-{
-    no_preemption();
-    current_thread->stats.last_reentry = clock_systime();
-    
-    set_preemption();
-    cpu_trap_sched();
-}
-
 __DEFINE_LXSYSCALL1(unsigned int, sleep, unsigned int, seconds)
 {
     if (!seconds) {
@@ -320,6 +310,7 @@ _wait(pid_t wpid, int* status, int options)
     }
 
     wpid = wpid ? wpid : -__current->pgid;
+
 repeat:
     llist_for_each(proc, n, &__current->children, siblings)
     {

--- a/lunaix-os/kernel/process/switch.c
+++ b/lunaix-os/kernel/process/switch.c
@@ -1,0 +1,37 @@
+#include <lunaix/switch.h>
+#include <lunaix/signal.h>
+#include <lunaix/sched.h>
+#include <lunaix/process.h>
+
+extern void
+signal_dispatch(struct signpost_result* result);
+
+extern void
+preempt_handle_stalled(struct signpost_result* result);
+
+#define do_signpost(fn, result)                         \
+    do {                                                \
+        fn((result));                                   \
+        if ((result)->mode == SWITCH_MODE_FAST) {       \
+            thread_stats_update_leaving();              \
+            return (result)->stack;                     \
+        }                                               \
+        if ((result)->mode == SWITCH_MODE_GIVEUP) {     \
+            schedule();                                 \
+            fail("unexpected return");                  \
+        }                                               \
+    } while (0)
+
+ptr_t
+switch_signposting()
+{
+    struct signpost_result result;
+
+    do_signpost(preempt_handle_stalled, &result);
+
+    do_signpost(signal_dispatch, &result);
+
+    thread_stats_update_leaving();
+
+    return 0;
+}

--- a/lunaix-os/kernel/process/thread.c
+++ b/lunaix-os/kernel/process/thread.c
@@ -194,8 +194,8 @@ thread_stats_update(bool inbound, bool voluntary)
     struct thread_stats* stats;
     time_t now;
 
-    now = clock_systime();
-    stats   = &current_thread->stats;
+    now   = clock_systime();
+    stats = &current_thread->stats;
 
     stats->at_user = !kernel_context(current_thread->hstate);
 

--- a/lunaix-os/kernel/syscall.c
+++ b/lunaix-os/kernel/syscall.c
@@ -1,0 +1,19 @@
+#include <lunaix/process.h>
+#include <lunaix/kpreempt.h>
+
+typedef reg_t (*syscall_fn)(reg_t p1, reg_t p2, reg_t p3, reg_t p4, reg_t p5);
+
+reg_t
+dispatch_syscall(void* syscall_fnptr, 
+                 reg_t p1, reg_t p2, reg_t p3, reg_t p4, reg_t p5)
+{
+    reg_t ret_val;
+    
+    thread_stats_update_entering(true);
+    
+    set_preemption();
+    ret_val = ((syscall_fn)syscall_fnptr)(p1, p2, p3, p4, p5);
+    no_preemption();
+
+    return ret_val;
+}

--- a/lunaix-os/kernel/time/timer.c
+++ b/lunaix-os/kernel/time/timer.c
@@ -123,6 +123,7 @@ timer_update()
 
     if (sched_ticks_counter >= sched_ticks) {
         sched_ticks_counter = 0;
+        thread_stats_update_entering(false);
         schedule();
     }
 }


### PR DESCRIPTION
```
This patch based on recent enabling of preemptive kernel
introduced in feat/fs/ext2 (as a consequence to improve
async blkio responsiveness). And have brings the following
quality of life improvements as well as some bug fixes.

QoL improvements:

1. Layout the basic thread statistics framework, allow
   kernel to collect some interesting metrics of threads.
2. Detection on stalling/hung/dead loop in kernel space 
   of any thread, enable more robust code and ease the
   debugging experience.

Fixes:

1. An outdated implementation on thread kernel stack reclaiming
   cause kernel stacks from other thread (within same address space)
   being corrupted. Thus failing the pthread test suite.


```