### PR TITLE
Improve cake allocator's memory utilisation

### DIFF
--- a/lunaix-os/includes/lunaix/mm/cake.h
+++ b/lunaix-os/includes/lunaix/mm/cake.h
@@ -58,8 +58,6 @@ struct cake_s
             piece_t free_list[0];
         };
     };
-
-    spinlock_t lock
 };
 
 /**

--- a/lunaix-os/includes/lunaix/mm/cake.h
+++ b/lunaix-os/includes/lunaix/mm/cake.h
@@ -6,7 +6,8 @@
 
 #define PILE_NAME_MAXLEN 20
 
-#define PILE_ALIGN_CACHE 1
+#define PILE_ALIGN_CACHE 0b0001
+#define PILE_FL_EXTERN   0b0010
 
 struct cake_pile;
 
@@ -24,22 +25,41 @@ struct cake_pile
     u32_t alloced_pieces;
     u32_t pieces_per_cake;
     u32_t pg_per_cake;
+    u32_t options;
     char pile_name[PILE_NAME_MAXLEN+1];
 
     pile_cb ctor;
 };
 
-typedef unsigned int piece_index_t;
+typedef unsigned short piece_t;
 
-#define EO_FREE_PIECE ((u32_t)-1)
+#define EO_FREE_PIECE ((piece_t)-1)
+
+#define CAKE_FL_SIZE        128 
+#define CAKE_FL_MAXLEN      \
+    ((unsigned int)((CAKE_FL_SIZE - sizeof(ptr_t)) / sizeof(piece_t)))
+struct cake_fl
+{
+    piece_t indices[CAKE_FL_MAXLEN];
+    struct cake_fl* next;
+} align(CAKE_FL_SIZE);
 
 struct cake_s
 {
     struct llist_header cakes;
+    struct cake_pile* owner;
     void* first_piece;
     unsigned int used_pieces;
     unsigned int next_free;
-    piece_index_t free_list[0];
+    union {
+        struct cake_fl* fl;
+        struct {
+            void* rsvd;
+            piece_t free_list[0];
+        };
+    };
+
+    spinlock_t lock
 };
 
 /**
@@ -82,6 +102,9 @@ cake_init();
 
 void
 cake_export();
+
+void
+cake_reclaim_freed();
 
 /********** some handy constructor ***********/
 

--- a/lunaix-os/kernel/mm/cake.c
+++ b/lunaix-os/kernel/mm/cake.c
@@ -2,7 +2,7 @@
  * @file cake.c
  * @author Lunaixsky (zelong56@gmail.com)
  * @brief A simplified cake(slab) allocator.
- *          P.s. I call it cake as slab sounds more 'ridge' to me. :)
+ *          P.s. I call it cake as slab sounds quite 'rigid' to me :)
  * @version 0.1
  * @date 2022-07-02
  *
@@ -20,12 +20,18 @@ LOG_MODULE("CAKE")
 
 #define CACHE_LINE_SIZE 128
 
-struct cake_pile master_pile;
+static struct cake_pile master_pile, fl_pile, cakes;
 
 struct llist_header piles = { .next = &piles, .prev = &piles };
 
-void*
-__alloc_cake(unsigned int cake_pg)
+static inline bool
+embedded_pile(struct cake_pile* pile)
+{
+    return !(pile->options & PILE_FL_EXTERN);
+}
+
+static void*
+__alloc_cake_pages(unsigned int cake_pg)
 {
     struct leaflet* leaflet = alloc_leaflet(count_order(cake_pg));
     if (!leaflet) {
@@ -35,35 +41,135 @@ __alloc_cake(unsigned int cake_pg)
     return (void*)vmap(leaflet, KERNEL_DATA);
 }
 
-struct cake_s*
-__new_cake(struct cake_pile* pile)
-{
-    struct cake_s* cake = __alloc_cake(pile->pg_per_cake);
+static struct cake_fl*
+__alloc_fl(piece_t prev_id, piece_t max_len) {
+    unsigned int i, j;
+    struct cake_fl* cake_fl;
+    
+    cake_fl = cake_grab(&fl_pile);
+    for (i = 0, j=prev_id; i < CAKE_FL_MAXLEN && j < max_len; i++, j++)
+    {
+        cake_fl->indices[i] = j + 1;
+    }
 
-    if (!cake) {
+    for (i -= 1; j == max_len && i < CAKE_FL_SIZE; i++) {
+        cake_fl->indices[i] = EO_FREE_PIECE;
+    }
+
+    cake_fl->next = NULL;
+    return cake_fl;
+}
+
+static void
+__free_fls(struct cake_s* cake) {
+    unsigned int i, j;
+    struct cake_fl *cake_fl, *next;
+    
+    cake_fl = cake->fl;
+    while (cake_fl)
+    {
+        next = cake_fl->next;
+        cake_release(&fl_pile, cake_fl);
+        cake_fl = next;
+    }
+
+    cake->fl = NULL;
+}
+
+static piece_t*
+__fl_slot(struct cake_s* cake, piece_t index) 
+{
+    int id_acc;
+    struct cake_fl* cake_fl;
+    struct cake_pile* pile;
+
+    pile = cake->owner;
+    if (embedded_pile(pile)) {
+        return &cake->free_list[index];
+    }
+
+    id_acc = 0;
+    cake_fl = cake->fl;
+    while (index >= CAKE_FL_MAXLEN)
+    {
+        index  -= CAKE_FL_MAXLEN;
+        id_acc += CAKE_FL_MAXLEN;
+
+        if (cake_fl->next) {
+            cake_fl = cake_fl->next;
+            continue;
+        }
+        
+        cake_fl = __alloc_fl(id_acc, pile->pieces_per_cake);
+        cake_fl->next = cake_fl;
+    }
+
+    return &cake_fl->indices[index];
+}
+
+static inline struct cake_s*
+__create_cake_extern(struct cake_pile* pile)
+{
+    struct cake_s* cake;
+    
+    cake = cake_grab(&cakes);
+    if (unlikely(!cake)) {
+        return NULL;
+    }
+
+    cake->first_piece = __alloc_cake_pages(pile->pg_per_cake);
+    cake->fl = __alloc_fl(0, pile->pieces_per_cake);
+    cake->next_free = 0;
+
+    return cake;
+}
+
+static inline struct cake_s*
+__create_cake_embed(struct cake_pile* pile)
+{
+    struct cake_s* cake;
+    
+    cake = __alloc_cake_pages(pile->pg_per_cake);
+    if (unlikely(!cake)) {
         return NULL;
     }
 
     u32_t max_piece = pile->pieces_per_cake;
 
     assert(max_piece);
-
+    
     cake->first_piece = (void*)((ptr_t)cake + pile->offset);
     cake->next_free = 0;
-    pile->cakes_count++;
 
-    piece_index_t* free_list = cake->free_list;
+    piece_t* free_list = cake->free_list;
     for (size_t i = 0; i < max_piece - 1; i++) {
         free_list[i] = i + 1;
     }
     free_list[max_piece - 1] = EO_FREE_PIECE;
 
+    return cake;
+}
+
+static struct cake_s*
+__new_cake(struct cake_pile* pile)
+{
+    struct cake_s* cake;
+
+    if (embedded_pile(pile)) {
+        cake = __create_cake_embed(pile);
+    }
+    else {
+        cake = __create_cake_extern(pile);
+    }
+    
+    cake->owner = pile;
+    pile->cakes_count++;
     llist_append(&pile->free, &cake->cakes);
 
     return cake;
 }
 
-void
+static void
 __init_pile(struct cake_pile* pile,
             char* name,
             unsigned int piece_size,
@@ -85,15 +191,28 @@ __init_pile(struct cake_pile* pile,
     piece_size = ROUNDUP(piece_size, offset);
     *pile = (struct cake_pile){ .piece_size = piece_size,
                                 .cakes_count = 0,
-                                .pieces_per_cake =
-                                  (pg_per_cake * PAGE_SIZE) /
-                                  (piece_size + sizeof(piece_index_t)),
+                                .options = options,
                                 .pg_per_cake = pg_per_cake };
 
-    unsigned int free_list_size = pile->pieces_per_cake * sizeof(piece_index_t);
+    if (!embedded_pile(pile)) {
+        pile->offset = 0;
+        pile->pieces_per_cake = (pg_per_cake * PAGE_SIZE) / piece_size;
+    }
+    else {
+        unsigned int free_list_size;
 
-    pile->offset = ROUNDUP(sizeof(struct cake_s) + free_list_size, offset);
-    pile->pieces_per_cake -= ICEIL((pile->offset - free_list_size), piece_size);
+        pile->pieces_per_cake 
+            = (pg_per_cake * PAGE_SIZE) /
+              (piece_size + sizeof(piece_t));
+        
+        free_list_size 
+            = pile->pieces_per_cake * sizeof(piece_t);
+
+        pile->offset 
+            = ROUNDUP(sizeof(struct cake_s) + free_list_size, offset);
+        pile->pieces_per_cake 
+            -= ICEIL((pile->offset - free_list_size), piece_size);
+    }
 
     strncpy(pile->pile_name, name, PILE_NAME_MAXLEN);
 
@@ -103,10 +222,49 @@ __init_pile(struct cake_pile* pile,
     llist_append(&piles, &pile->piles);
 }
 
+static void
+__destory_cake(struct cake_s* cake)
+{
+    // Pinkie Pie is going to MAD!
+
+    struct leaflet* leaflet;
+    struct cake_pile* owner;
+    pfn_t _pfn;
+
+    _pfn = pfn(vmm_v2p(cake->first_piece));
+    leaflet = ppfn_leaflet(_pfn);
+    owner = cake->owner;
+
+    assert(!cake->used_pieces);
+
+    llist_delete(&cake->cakes);
+    owner->cakes_count--;
+
+    
+    if (!embedded_pile(cake)) {
+        __free_fls(cake);
+        cake_release(&cakes, cake); 
+        vunmap(cake->first_piece, leaflet);
+    }
+    else {
+        vunmap(__ptr(cake), leaflet);
+    }
+
+done:
+    leaflet_return(leaflet);
+}
+
 void
 cake_init()
 {
-    __init_pile(&master_pile, "pinkamina", sizeof(master_pile), 1, 0);
+    // pinkamina is our master, no one shall precede her.
+    __init_pile(&master_pile, "pinkamina", 
+                sizeof(master_pile), 1, 0);
+
+    __init_pile(&fl_pile, "gummy", \
+                sizeof(struct cake_fl), 1, 0);
+    __init_pile(&cakes, "cakes", \
+                sizeof(struct cake_s), 1, 0);
 }
 
 struct cake_pile*
@@ -145,33 +303,40 @@ cake_grab(struct cake_pile* pile)
 
     if (!pos)
         return NULL;
+    
+    void* piece;
+    piece_t found_index, *fl_slot;
+    
+    found_index = pos->next_free;
+    fl_slot = __fl_slot(pos, found_index);
 
-    piece_index_t found_index = pos->next_free;
-    pos->next_free = pos->free_list[found_index];
+    pos->next_free = *fl_slot;
     pos->used_pieces++;
     pile->alloced_pieces++;
 
     llist_delete(&pos->cakes);
-    if (pos->free_list[pos->next_free] == EO_FREE_PIECE) {
+
+    fl_slot = __fl_slot(pos, pos->next_free);
+    if (*fl_slot == EO_FREE_PIECE) {
         llist_append(&pile->full, &pos->cakes);
     } else {
         llist_append(&pile->partial, &pos->cakes);
     }
 
-    void* ptr =
-      (void*)((ptr_t)pos->first_piece + found_index * pile->piece_size);
+    piece =
+      (void*)(__ptr(pos->first_piece) + found_index * pile->piece_size);
 
     if (pile->ctor) {
-        pile->ctor(pile, ptr);
+        pile->ctor(pile, piece);
     }
 
-    return ptr;
+    return piece;
 }
 
 int
 cake_release(struct cake_pile* pile, void* area)
 {
-    piece_index_t piece_index;
+    piece_t piece_index;
     size_t dsize = 0;
     struct cake_s *pos, *n;
     struct llist_header* hdrs[2] = { &pile->full, &pile->partial };
@@ -194,10 +359,14 @@ cake_release(struct cake_pile* pile, void* area)
 
 found:
     assert(!(dsize % pile->piece_size));
-    pos->free_list[piece_index] = pos->next_free;
+
+    piece_t *fl_slot;
+
+    fl_slot = __fl_slot(pos, piece_index);
+    *fl_slot = pos->next_free;
     pos->next_free = piece_index;
 
-    assert_msg(pos->free_list[piece_index] != pos->next_free, "double free");
+    assert_msg(*fl_slot != pos->next_free, "double free");
 
     pos->used_pieces--;
     pile->alloced_pieces--;
@@ -218,4 +387,24 @@ void
 cake_ctor_zeroing(struct cake_pile* pile, void* piece)
 {
     memset(piece, 0, pile->piece_size);
+}
+
+static inline void
+__reclaim(struct cake_pile *pile)
+{
+    struct cake_s *pos, *n;
+    llist_for_each(pos, n, &pile->free, cakes)
+    {
+        __destory_cake(pos);
+    }
+}
+
+void
+cake_reclaim_freed()
+{
+    struct cake_pile *pos, *n;
+    llist_for_each(pos, n, &master_pile.piles, piles)
+    {
+        __reclaim(pos);
+    }
 }

--- a/lunaix-os/kernel/mm/cake.c
+++ b/lunaix-os/kernel/mm/cake.c
@@ -230,27 +230,27 @@ __destory_cake(struct cake_s* cake)
     struct leaflet* leaflet;
     struct cake_pile* owner;
     pfn_t _pfn;
+    ptr_t page_va;
 
-    _pfn = pfn(vmm_v2p(cake->first_piece));
-    leaflet = ppfn_leaflet(_pfn);
     owner = cake->owner;
-
     assert(!cake->used_pieces);
 
     llist_delete(&cake->cakes);
     owner->cakes_count--;
-
     
-    if (!embedded_pile(cake)) {
+    if (!embedded_pile(owner)) {
+        page_va = __ptr(cake->first_piece);
         __free_fls(cake);
         cake_release(&cakes, cake); 
-        vunmap(cake->first_piece, leaflet);
     }
     else {
-        vunmap(__ptr(cake), leaflet);
+        page_va = __ptr(cake);
     }
 
-done:
+    _pfn = pfn(vmm_v2p(page_va));
+    leaflet = ppfn_leaflet(_pfn);
+    vunmap(page_va, leaflet);
+
     leaflet_return(leaflet);
 }
 

--- a/lunaix-os/kernel/mm/cake_export.c
+++ b/lunaix-os/kernel/mm/cake_export.c
@@ -18,7 +18,7 @@ void
 __cake_stat_reset(struct twimap* map)
 {
     map->index = container_of(&piles, struct cake_pile, piles);
-    twimap_printf(map, "name, n_cakes, pg/cake, slices/cake, n_slices\n");
+    twimap_printf(map, "name cakes pages size slices actives\n");
 }
 
 void
@@ -26,10 +26,11 @@ __cake_rd_stat(struct twimap* map)
 {
     struct cake_pile* pos = twimap_index(map, struct cake_pile*);
     twimap_printf(map,
-                  "%s %d %d %d %d\n",
+                  "%s %d %d %d %d %d\n",
                   pos->pile_name,
                   pos->cakes_count,
                   pos->pg_per_cake,
+                  pos->piece_size,
                   pos->pieces_per_cake,
                   pos->alloced_pieces);
 }


### PR DESCRIPTION
```
This patch improves the allocator's memory utilisation
by separating the cake metadata into a separate memory
region. Prior to this, the metadata and the allocated
memory region are sharing the same leaflet. Thus induce
large inner fragmentation when the object size is 
apporaching the leaflet size. 

We introduce a new pile option `FL_EXTERN` to enable this
separation. In order to differentiate the piles, we refer
the pile without separation as `embeded pile` and those with
separation as `separated pile`.

Evaluation

We define the memory utilisation of a pile (U) as :

         (size of all allocatable objects)
    U =  -----------------------------------
         (size of leaflet + cake overhead)

where the cake overhead refer to the memory overhead
required to house the cake metadata. For embeded pile
this term is always 0.

In analysis of the cake allocation algorithm. We consider
the commonly used valloc() size, that is the napot value 
from 8 to 8k. And two different allocation cases: leaflet
order increased for large allocation object; leaflet order
remain constant (order 0) for all objects. We denote U1 and
U2 as utilisation for embeded pile and separated pile 
respectively. Result as present in below table

objsize   order     U1      U2   |  order    U1      U2 
 8          0     0.789   0.781  |    0    0.789   0.781
 16         0     0.875   0.872  |    0    0.875   0.872
 32         0     0.922   0.926  |    0    0.922   0.926
 64         0     0.953   0.955  |    0    0.953   0.955
 128        0     0.969   0.971  |    0    0.969   0.971
 256        1     0.969   0.985  |    0    0.938   0.978
 512        1     0.938   0.989  |    0    0.875   0.982
 1024       2     0.938   0.995  |    0    0.750   0.984
 2048       2     0.875   0.996  |    0    0.500   0.985
 4096       3     0.875   0.998  |    0    0.000   0.986
 8192       3     0.750   0.998  |    0    0.000   0.986

It can be seem U2 remain the incrase trends even for large
object. Increasing the leaflet order does mitigate the 
decreasing trend but still significant.

Most interestingly, U1 and U2 starts to divert after 
objsize=256. We could identify this point where the 
fragmentation start to become no longer negligible.

This could provide a sound suggestion for the critical
point where FL_EXTERN enablement is encouraged. The reason
we do not enable FL_EXTERN for all sizes is the overhead of
accessing the free list. As they are all partitioned into 
linked blocks, each housing at most 60 indices.
```
