### PR TITLE
Fix: stale dnode caching instance cause locked-up upon accessing

### DIFF
--- a/lunaix-os/kernel/fs/mount.c
+++ b/lunaix-os/kernel/fs/mount.c
@@ -11,8 +11,16 @@ LOG_MODULE("fs")
 
 struct llist_header all_mnts = { .next = &all_mnts, .prev = &all_mnts };
 
-struct v_mount*
-vfs_create_mount(struct v_mount* parent, struct v_dnode* mnt_point)
+static void
+__vfs_attach_vmnt(struct v_dnode* mnt_point, struct v_mount* vmnt)
+{
+    vmnt->mnt_point = mnt_point;
+    atomic_fetch_add(&mnt_point->ref_count, 1);
+    vfs_d_assign_vmnt(mnt_point, vmnt);
+}
+
+static struct v_mount*
+__vfs_create_mount(struct v_mount* parent, struct v_superblock* mnt_sb)
 {
     struct v_mount* mnt = vzalloc(sizeof(struct v_mount));
     if (!mnt) {
@@ -25,8 +33,7 @@ vfs_create_mount(struct v_mount* parent, struct v_dnode* mnt_point)
     mutex_init(&mnt->lock);
 
     mnt->parent = parent;
-    mnt->mnt_point = mnt_point;
-    vfs_vmnt_assign_sb(mnt, mnt_point->super_block);
+    vfs_vmnt_assign_sb(mnt, mnt_sb);
 
     if (parent) {
         mnt_mkbusy(parent);
@@ -34,14 +41,12 @@ vfs_create_mount(struct v_mount* parent, struct v_dnode* mnt_point)
         llist_append(&parent->submnts, &mnt->sibmnts);
         mutex_unlock(&mnt->parent->lock);
     }
-    
-    atomic_fetch_add(&mnt_point->ref_count, 1);
 
     return mnt;
 }
 
-void
-__vfs_release_vmnt(struct v_mount* mnt)
+static void
+__vfs_detach_vmnt(struct v_mount* mnt)
 {
     assert(llist_empty(&mnt->submnts));
 
@@ -49,13 +54,25 @@ __vfs_release_vmnt(struct v_mount* mnt)
         mnt_chillax(mnt->parent);
     }
 
+    mnt->mnt_point->mnt = NULL;
+
     llist_delete(&mnt->sibmnts);
     llist_delete(&mnt->list);
     atomic_fetch_sub(&mnt->mnt_point->ref_count, 1);
     vfree(mnt);
 }
 
-int
+static inline void
+__detach_node_cache_ref(struct hbucket* bucket)
+{
+    if (!bucket->head) {
+        return;
+    }
+
+    bucket->head->pprev = 0;
+}
+
+static int
 __vfs_do_unmount(struct v_mount* mnt)
 {
     int errno = 0;
@@ -67,17 +84,12 @@ __vfs_do_unmount(struct v_mount* mnt)
 
     // detached the inodes from cache, and let lru policy to recycle them
     for (size_t i = 0; i < VFS_HASHTABLE_SIZE; i++) {
-        struct hbucket* bucket = &sb->i_cache[i];
-        if (!bucket->head) {
-            continue;
-        }
-        bucket->head->pprev = 0;
+        __detach_node_cache_ref(&sb->i_cache[i]);
+        __detach_node_cache_ref(&sb->d_cache[i]);
     }
 
-    mnt->mnt_point->mnt = mnt->parent;
-
-    vfs_sb_free(sb);
-    __vfs_release_vmnt(mnt);
+    __vfs_detach_vmnt(mnt);
+    vfs_d_assign_vmnt(mnt->mnt_point, mnt->parent);
 
     return errno;
 }
@@ -163,27 +175,30 @@ vfs_mount_fsat(struct filesystem* fs,
     }
 
     int errno = 0;
-    char* dev_name = "sys";
-    char* fsname = HSTR_VAL(fs->fs_name);
+    char* dev_name;
+    char* fsname;
+    struct v_mount *parent_mnt, *vmnt;
+    struct v_superblock *sb;
 
-    struct v_mount* parent_mnt = mnt_point->mnt;
-    struct v_superblock *sb = vfs_sb_alloc(), 
-                        *old_sb = mnt_point->super_block;
+    fsname = HSTR_VAL(fs->fs_name);
+    parent_mnt = mnt_point->mnt;
+    sb = vfs_sb_alloc();
 
-    if (device) {
-        dev_name = device->name_val;
-    }
+    dev_name = device ? device->name_val : "sys";
 
     // prepare v_superblock for fs::mount invoke
     sb->dev = device;
     sb->fs = fs;
     sb->root = mnt_point;
-    vfs_d_assign_sb(mnt_point, sb);
+    
+    vmnt = __vfs_create_mount(parent_mnt, sb);
 
-    if (!(mnt_point->mnt = vfs_create_mount(parent_mnt, mnt_point))) {
+    if (!vmnt) {
         errno = ENOMEM;
         goto cleanup;
     }
+
+    __vfs_attach_vmnt(mnt_point, vmnt);
 
     mnt_point->mnt->flags = options;
     if (!(errno = fs->mount(sb, mnt_point))) {
@@ -193,16 +208,14 @@ vfs_mount_fsat(struct filesystem* fs,
         goto cleanup;
     }
 
-    vfs_sb_free(old_sb);
     return errno;
 
 cleanup:
     ERROR("failed mount: dev=%s, fs=%s, mode=%d, err=%d",
             dev_name, fsname, options, errno);
 
-    vfs_d_assign_sb(mnt_point, old_sb);
-    vfs_sb_free(sb);
-    __vfs_release_vmnt(mnt_point->mnt);
+    __vfs_detach_vmnt(mnt_point->mnt);
+    vfs_d_assign_vmnt(mnt_point, parent_mnt);
 
     mnt_point->mnt = parent_mnt;
 

--- a/lunaix-os/libs/hash.c
+++ b/lunaix-os/libs/hash.c
@@ -2,9 +2,12 @@
 #include <lunaix/compiler.h>
 
 /**
- * @brief Simple string hash function
+ * @brief Simple string hash function (sdbm)
  *
- * ref: https://stackoverflow.com/a/7666577
+ * ref: http://www.cse.yorku.ca/~oz/hash.html
+ * 
+ * sdbm has lower standard deviation in bucket distribution
+ * than djb2 (previously used) for low bucket size (16, 32).
  *
  * @param str
  * @return unsigned int
@@ -15,11 +18,11 @@ strhash_32(const char* str, u32_t truncate_to)
     if (!str)
         return 0;
 
-    u32_t hash = 5381;
+    u32_t hash = 0;
     int c;
 
     while ((c = *str++))
-        hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+        hash = (hash << 6) + (hash << 16) + c - hash;
 
     return hash >> (HASH_SIZE_BITS - truncate_to);
 }


### PR DESCRIPTION
Directory entry from a recently remounted file system got traped into lock-up state upon accessing if it has been previously accessed before unmount.

The root casue is the global cache pool of v_dnode structure that does not played well together with async cache invalidation design. That is, a v_dnode cache, deep into tree hierarchy, created by an access from previous mount session, is still reachable through hash indexing in the succeeding mount session.

A fix is proposed by demote level of the cache pool to each superblock, isolating between sessions.