### PR TITLE
Fix file system racing and ext2 directory insertion

### DIFF
--- a/lunaix-os/includes/lunaix/ds/mutex.h
+++ b/lunaix-os/includes/lunaix/ds/mutex.h
@@ -6,7 +6,7 @@
 
 typedef struct mutex_s
 {
-    atomic_ulong lk;
+    atomic_uint lk;
     pid_t owner;
 } mutex_t;
 
@@ -36,5 +36,8 @@ mutex_unlock_nested(mutex_t* mutex);
 
 void
 mutex_unlock_for(mutex_t* mutex, pid_t pid);
+
+bool
+mutex_trylock(mutex_t* mutex);
 
 #endif /* __LUNAIX_MUTEX_H */

--- a/lunaix-os/includes/lunaix/ds/rwlock.h
+++ b/lunaix-os/includes/lunaix/ds/rwlock.h
@@ -14,6 +14,9 @@ typedef struct rwlock_s
 } rwlock_t;
 
 void
+rwlock_init(rwlock_t* rwlock);
+
+void
 rwlock_begin_read(rwlock_t* rwlock);
 
 void

--- a/lunaix-os/includes/lunaix/ds/spinlock.h
+++ b/lunaix-os/includes/lunaix/ds/spinlock.h
@@ -8,6 +8,9 @@ struct spinlock
     volatile bool flag;
 };
 
+#define DEFINE_SPINLOCK(name)   \
+    struct spinlock name = { .flag = false }
+
 typedef struct spinlock spinlock_t;
 
 /*

--- a/lunaix-os/includes/lunaix/fs.h
+++ b/lunaix-os/includes/lunaix/fs.h
@@ -62,17 +62,17 @@
      ('0' <= (chr) && (chr) <= '9') || (chr) == '.' || (chr) == '_' ||         \
      (chr) == '-' || (chr) == ':')
 
-#define unlock_inode(inode) mutex_unlock(&inode->lock)
+#define unlock_inode(inode) mutex_unlock_nested(&inode->lock)
 #define lock_inode(inode)                                                      \
     ({                                                                         \
-        mutex_lock(&inode->lock);                                              \
+        mutex_lock_nested(&inode->lock);                                       \
         lru_use_one(inode_lru, &inode->lru);                                   \
     })
 
-#define unlock_dnode(dnode) mutex_unlock(&dnode->lock)
+#define unlock_dnode(dnode) mutex_unlock_nested(&dnode->lock)
 #define lock_dnode(dnode)                                                      \
     ({                                                                         \
-        mutex_lock(&dnode->lock);                                              \
+        mutex_lock_nested(&dnode->lock);                                       \
         lru_use_one(dnode_lru, &dnode->lru);                                   \
     })
 

--- a/lunaix-os/kernel/fs/LConfig
+++ b/lunaix-os/kernel/fs/LConfig
@@ -19,3 +19,5 @@ def file_system():
         type(bool)
         default(True)
 
+
+include("ext2")

--- a/lunaix-os/kernel/fs/ext2/LConfig
+++ b/lunaix-os/kernel/fs/ext2/LConfig
@@ -1,0 +1,11 @@
+
+@Collection("ext2")
+def ext2_fs():
+    add_to_collection(file_system)
+
+    @Term("Debug Messages")
+    def ext2_debug_msg():
+        type(bool)
+        default(False)
+
+    return v(fs_ext2)

--- a/lunaix-os/kernel/fs/ext2/alloc.c
+++ b/lunaix-os/kernel/fs/ext2/alloc.c
@@ -4,12 +4,20 @@ static inline unsigned int
 __ext2_global_slot_alloc(struct v_superblock* vsb, int type_sel, 
                          struct ext2_gdesc** gd_out)
 {
+    int alloc;
     struct ext2_sbinfo* sb;
     struct ext2_gdesc *pos;
     struct llist_header *header;
     
+    alloc = ALLOC_FAIL;
     sb = EXT2_SB(vsb);
+
+    ext2sb_lock(sb);
     header = &sb->free_list_sel[type_sel];
+
+    // we have used up all avaliable inodes/blocks
+    if (llist_empty(header))
+        goto done;
     
     if (type_sel == GDESC_INO_SEL) {
         pos = list_entry(header->next, struct ext2_gdesc, free_grps_ino);
@@ -18,12 +26,14 @@ __ext2_global_slot_alloc(struct v_superblock* vsb, int type_sel,
         pos = list_entry(header->next, struct ext2_gdesc, free_grps_blk);
     }
 
-    int alloc = ext2gd_alloc_slot(pos, type_sel);
+    alloc = ext2gd_alloc_slot(pos, type_sel);
 
     if (valid_bmp_slot(alloc)) {
         *gd_out = pos;
     }
 
+done:
+    ext2sb_unlock(sb);
     return alloc;
 }
 
@@ -45,13 +55,15 @@ ext2gd_alloc_slot(struct ext2_gdesc* gd, int type_sel)
     struct ext2_bmp* bmp;
     struct ext2_sbinfo *sb;
     int alloc;
+
+    ext2gd_lock(gd);
     
     sb = gd->sb;
     bmp = &gd->bmps[type_sel];
-    alloc = ext2bmp_alloc_one(bmp);
+    alloc = ext2bmp_alloc_nolock(bmp);
     
     if (alloc < 0) {
-        return alloc;
+        goto done;
     }
 
     if (!ext2bmp_check_free(bmp)) {
@@ -66,8 +78,11 @@ ext2gd_alloc_slot(struct ext2_gdesc* gd, int type_sel)
         sb->raw->s_free_blk_cnt--;
     }
 
-    fsblock_dirty(gd->buf);
-    fsblock_dirty(sb->buf);
+    ext2gd_schedule_sync(gd);
+    ext2sb_schedule_sync(sb);
+
+done:
+    ext2gd_unlock(gd);
     return alloc;
 }
 
@@ -77,7 +92,9 @@ ext2gd_free_slot(struct ext2_gdesc* gd, int type_sel, int slot)
     struct llist_header *free_ent, *free_list;
     struct ext2_sbinfo *sb;
 
-    ext2bmp_free_one(&gd->bmps[type_sel], slot);
+    ext2gd_lock(gd);
+
+    ext2bmp_free_nolock(&gd->bmps[type_sel], slot);
 
     sb = gd->sb;
     free_ent  = &gd->free_list_sel[slot];
@@ -86,6 +103,7 @@ ext2gd_free_slot(struct ext2_gdesc* gd, int type_sel, int slot)
         llist_append(free_list, free_ent);
     }
 
+    // FIXME might need arch-depedent impl for atomic operations
     if (type_sel == GDESC_INO_SEL) {
         gd->info->bg_free_ino_cnt++;
         sb->raw->s_free_ino_cnt++;
@@ -94,6 +112,8 @@ ext2gd_free_slot(struct ext2_gdesc* gd, int type_sel, int slot)
         sb->raw->s_free_blk_cnt++;
     }
 
-    fsblock_dirty(gd->buf);
-    fsblock_dirty(sb->buf);
+    ext2gd_schedule_sync(gd);
+    ext2sb_schedule_sync(sb);
+
+    ext2gd_unlock(gd);
 }

--- a/lunaix-os/kernel/fs/ext2/dir.c
+++ b/lunaix-os/kernel/fs/ext2/dir.c
@@ -57,10 +57,11 @@ done:
 _ret:
     fsblock_put(prev_buf);
     ext2dr_itend(&iter);
+    
     return itstate_sel(&iter, errno);
 }
 
-static size_t
+static inline size_t
 __dirent_realsize(struct ext2b_dirent* dirent)
 {
     return sizeof(*dirent) - sizeof(dirent->name) + dirent->name_len;

--- a/lunaix-os/kernel/fs/ext2/ext2.h
+++ b/lunaix-os/kernel/fs/ext2/ext2.h
@@ -7,6 +7,13 @@
 #include <lunaix/ds/hashtable.h>
 #include <lunaix/ds/lru.h>
 
+#ifdef CONFIG_EXT2_DEBUG_MSG
+#   include <lunaix/syslog.h>
+#   define ext2_debug(fmt, ...)  kprintf_v("ext2", fmt, ##__VA_ARGS__)
+#else
+#   define ext2_debug(fmt, ...)
+#endif
+
 #define FEAT_COMPRESSION      0b00000001
 #define FEAT_RESIZE_INO       0b00000010
 #define FEAT_FILETYPE         0b00000100
@@ -269,7 +276,8 @@ struct ext2_inode
     bbuf_t buf;                  // partial inotab that holds this inode
     unsigned int inds_lgents;       // log2(# of block in an indirection level)
     unsigned int ino_id;
-    size_t indirect_blocks;
+    size_t nr_fsblks;
+    size_t nr_indblks;
     size_t isize;
 
     struct ext2b_inode* ino;        // raw ext2 inode
@@ -405,8 +413,11 @@ ext2ino_linkto(struct ext2_inode* e_ino, struct ext2b_dirent* dirent)
     fsblock_dirty(e_ino->buf);
 }
 
+#define DBIT_MODE_ISIZE 0
+#define DBIT_MODE_BLOCK 1
+
 void
-ext2db_itbegin(struct ext2_iterator* iter, struct v_inode* inode);
+ext2db_itbegin(struct ext2_iterator* iter, struct v_inode* inode, int mode);
 
 void
 ext2db_itend(struct ext2_iterator* iter);

--- a/lunaix-os/kernel/fs/ext2/file.c
+++ b/lunaix-os/kernel/fs/ext2/file.c
@@ -96,7 +96,7 @@ ext2_inode_read(struct v_inode *inode,
     blksz = e_sb->block_size;
     end = fpos + len;
 
-    ext2db_itbegin(&iter, inode);
+    ext2db_itbegin(&iter, inode, DBIT_MODE_ISIZE);
     ext2db_itffw(&iter, fpos / blksz);
 
     while (fpos < end && ext2db_itnext(&iter)) {
@@ -134,7 +134,7 @@ ext2_inode_read_page(struct v_inode *inode, void *buffer, size_t fpos)
     n = PAGE_SIZE / e_sb->block_size;
     transfer_sz = MIN(PAGE_SIZE, e_sb->block_size);
 
-    ext2db_itbegin(&iter, inode);
+    ext2db_itbegin(&iter, inode, DBIT_MODE_ISIZE);
     ext2db_itffw(&iter, blk_start);
 
     while (n-- && ext2db_itnext(&iter)) 

--- a/lunaix-os/kernel/fs/ext2/file.c
+++ b/lunaix-os/kernel/fs/ext2/file.c
@@ -12,7 +12,6 @@ ext2_open_inode(struct v_inode* inode, struct v_file* file)
     struct ext2_file* e_file;
 
     e_file = valloc(sizeof(*e_file));
-    e_file->b_ino = EXT2_INO(inode);
     
     file->data = e_file;
 

--- a/lunaix-os/kernel/fs/ext2/group.c
+++ b/lunaix-os/kernel/fs/ext2/group.c
@@ -89,8 +89,8 @@ __try_load_bitmap(struct v_superblock* vsb,
     struct ext2_sbinfo* ext2sb;
     struct ext2_bmp* bmp;
     struct llist_header* flist, *flist_entry;
+    unsigned int bmp_blk_id, bmp_size;
     bbuf_t buf;
-    unsigned int blk_id, bmp_blk_id, bmp_size;
 
     ext2sb = EXT2_SB(vsb);
 
@@ -111,8 +111,7 @@ __try_load_bitmap(struct v_superblock* vsb,
     flist = &ext2sb->free_list_sel[type];
     flist_entry = &gd->free_list_sel[type];
 
-    blk_id = ext2_datablock(vsb, bmp_blk_id);
-    buf    = fsblock_get(vsb, blk_id);
+    buf = fsblock_get(vsb, bmp_blk_id);
     if (blkbuf_errbuf(buf)) {
         return false;
     }

--- a/lunaix-os/kernel/fs/ext2/group.c
+++ b/lunaix-os/kernel/fs/ext2/group.c
@@ -126,7 +126,7 @@ __try_load_bitmap(struct v_superblock* vsb,
 }
 
 int
-ext2gd_take(struct v_superblock* vsb, 
+ext2gd_take_at(struct v_superblock* vsb, 
                unsigned int index, struct ext2_gdesc** out)
 {
     bbuf_t part, buf;
@@ -168,6 +168,8 @@ ext2gd_take(struct v_superblock* vsb,
         .base = index * ext2sb->raw->s_blk_per_grp,
         .ino_base = index * ext2sb->raw->s_ino_per_grp
     };
+
+    mutex_init(&gd->lock);
 
     *out = gd;
     
@@ -235,16 +237,8 @@ ext2bmp_init(struct ext2_bmp* e_bmp, bbuf_t bmp_buf, unsigned int nr_bits)
     __ext2bmp_update_next_free_cell(e_bmp);
 }
 
-bool
-ext2bmp_check_free(struct ext2_bmp* e_bmp)
-{
-    assert(e_bmp->raw);
-
-    return valid_bmp_slot(e_bmp->next_free);
-}
-
 int
-ext2bmp_alloc_one(struct ext2_bmp* e_bmp)
+ext2bmp_alloc_nolock(struct ext2_bmp* e_bmp)
 {
     assert(e_bmp->raw);
     
@@ -275,7 +269,7 @@ ext2bmp_alloc_one(struct ext2_bmp* e_bmp)
 }
 
 void
-ext2bmp_free_one(struct ext2_bmp* e_bmp, unsigned int pos)
+ext2bmp_free_nolock(struct ext2_bmp* e_bmp, unsigned int pos)
 {
     assert(e_bmp->raw);
 
@@ -291,7 +285,7 @@ ext2bmp_free_one(struct ext2_bmp* e_bmp, unsigned int pos)
 }
 
 void
-ext2bmp_discard(struct ext2_bmp* e_bmp)
+ext2bmp_discard_nolock(struct ext2_bmp* e_bmp)
 {
     assert(e_bmp->raw);
 

--- a/lunaix-os/kernel/fs/ext2/inode.c
+++ b/lunaix-os/kernel/fs/ext2/inode.c
@@ -391,7 +391,7 @@ __get_group_desc(struct v_superblock* vsb, int ino,
     sb = EXT2_SB(vsb);
 
     blkgrp_id = to_fsblock_id(ino) / sb->raw->s_ino_per_grp;
-    return ext2gd_take(vsb, blkgrp_id, gd_out);
+    return ext2gd_take_at(vsb, blkgrp_id, gd_out);
 }
 
 static struct ext2b_inode*
@@ -443,7 +443,7 @@ __create_inode(struct v_superblock* vsb, struct ext2_gdesc* gd, int ino_index)
     inode->btlb      = vzalloc(sizeof(struct ext2_btlb));
     inode->buf       = ino_tab;
     inode->ino       = b_inode;
-    inode->blk_grp   = gd;
+    inode->blk_grp   = ext2gd_take(gd);
     inode->isize     = b_inode->i_size;
 
     if (ext2_feature(vsb, FEAT_LARGE_FILE)) {
@@ -592,7 +592,7 @@ __free_block_at(struct v_superblock *vsb, unsigned int block_pos)
     sb = EXT2_SB(vsb);
     gd_index = block_pos / sb->raw->s_blk_per_grp;
 
-    if ((errno = ext2gd_take(vsb, gd_index, &gd))) {
+    if ((errno = ext2gd_take_at(vsb, gd_index, &gd))) {
         return errno;
     }
 

--- a/lunaix-os/kernel/fs/ext2/mount.c
+++ b/lunaix-os/kernel/fs/ext2/mount.c
@@ -170,6 +170,8 @@ ext2_mount(struct v_superblock* vsb, struct v_dnode* mnt)
     ext2sb->raw = rawsb;
     ext2sb->all_feature = __translate_feature(rawsb);
 
+    mutex_init(&ext2sb->lock);
+
     fsapi_set_vsb_ops(vsb, &vsb_ops);
     fsapi_complete_vsb_setup(vsb, ext2sb);
 
@@ -187,6 +189,9 @@ ext2_mount(struct v_superblock* vsb, struct v_dnode* mnt)
     else {
         ext2sb->raw = offset(blkbuf_data(buf), EXT2_BASE_BLKSZ);
     }
+
+    ext2sb->raw->s_mnt_cnt++;
+    ext2sb->raw->s_mtime = clock_unixtime();
 
     ext2sb->buf = buf;
     vfree(rawsb);

--- a/lunaix-os/kernel/fs/mount.c
+++ b/lunaix-os/kernel/fs/mount.c
@@ -86,8 +86,8 @@ __vfs_do_unmount(struct v_mount* mnt)
 
     // detached the inodes from cache, and let lru policy to recycle them
     for (size_t i = 0; i < VFS_HASHTABLE_SIZE; i++) {
-        __detach_node_cache_ref(&sb->i_cache[i]);
-        __detach_node_cache_ref(&sb->d_cache[i]);
+        __detach_node_cache_ref(&sb->i_cache.pool[i]);
+        __detach_node_cache_ref(&sb->d_cache.pool[i]);
     }
 
     struct v_dnode *pos, *next;

--- a/lunaix-os/kernel/fs/vfs.c
+++ b/lunaix-os/kernel/fs/vfs.c
@@ -102,21 +102,54 @@ vfs_init()
     vfs_sysroot->parent = vfs_sysroot;
     
     vfs_ref_dnode(vfs_sysroot);
+    lru_remove(dnode_lru, &vfs_sysroot->lru);
+}
+
+void
+vfs_vncache_init(struct vncache* cache)
+{
+    cache->pool = vzalloc(VFS_HASHTABLE_SIZE * sizeof(struct hbucket));
+    rwlock_init(&cache->lock);
+}
+
+void
+vfs_vncache_free(struct vncache* cache)
+{
+    // clear all other reader/writer
+    rwlock_begin_write(&cache->lock);
+    vfree(cache->pool);
+    
+    // already freed, so as the lock
+}
+
+void
+vfs_vncache_add(struct vncache* cache, size_t key, struct hlist_node* node)
+{
+    struct hbucket* slot;
+
+    cache_atomic_write(cache, 
+    {
+        slot = &cache->pool[key & VFS_HASH_MASK];
+        hlist_delete(node);
+        hlist_add(&slot->head, node);
+    });
 }
 
 static inline struct hbucket*
-__dcache_hash(struct v_dnode* parent, u32_t* hash)
+__dcache_hash_nolock(struct v_dnode* parent, u32_t* hash)
 {
+    struct v_superblock* sb;
     struct hbucket* d_cache;
     u32_t _hash;
+
+    sb = parent->super_block;
     
-    d_cache = parent->super_block->d_cache;
     _hash = *hash;
     _hash = _hash ^ (_hash >> VFS_HASHBITS);
     _hash += (u32_t)__ptr(parent);
 
     *hash = _hash;
-    return &d_cache[_hash & VFS_HASH_MASK];
+    return &sb->d_cache.pool[_hash & VFS_HASH_MASK];
 }
 
 static inline int
@@ -135,6 +168,11 @@ __sync_inode_nolock(struct v_inode* inode)
 struct v_dnode*
 vfs_dcache_lookup(struct v_dnode* parent, struct hstr* str)
 {
+    u32_t hash;
+    struct hbucket* slot;
+    struct v_dnode *pos, *n;
+    struct vncache *dcache;
+ 
     if (!str->len || HSTR_EQ(str, &vfs_dot))
         return parent;
 
@@ -142,16 +180,23 @@ vfs_dcache_lookup(struct v_dnode* parent, struct hstr* str)
         return parent->parent;
     }
 
-    u32_t hash = str->hash;
-    struct hbucket* slot = __dcache_hash(parent, &hash);
+    hash = str->hash;
+    dcache = dnode_cache(parent);
+    
+    vncache_lock_read(dcache);
 
-    struct v_dnode *pos, *n;
+    slot = __dcache_hash_nolock(parent, &hash);
     hashtable_bucket_foreach(slot, pos, n, hash_list)
     {
-        if (pos->name.hash == hash && pos->parent == parent) {
-            return pos;
+        if (pos->name.hash != hash || pos->parent != parent) {
+            continue;
         }
+
+        vncache_unlock_read(dcache);
+        return pos;
     }
+
+    vncache_unlock_read(dcache);
     return NULL;
 }
 
@@ -172,14 +217,21 @@ __vfs_touch_inode(struct v_inode* inode, const int type)
 void
 vfs_dcache_add(struct v_dnode* parent, struct v_dnode* dnode)
 {
+    struct hbucket* bucket;
+    struct vncache* cache;
+
     assert(parent);
+    assert(locked_node(parent));
 
     dnode->ref_count = 1;
     dnode->parent = parent;
     llist_append(&parent->children, &dnode->siblings);
 
-    struct hbucket* bucket = __dcache_hash(parent, &dnode->name.hash);
-    hlist_add(&bucket->head, &dnode->hash_list);
+    cache_atomic_write(dnode_cache(parent), 
+    {
+        bucket = __dcache_hash_nolock(parent, &dnode->name.hash);
+        hlist_add(&bucket->head, &dnode->hash_list);
+    });
 }
 
 void
@@ -190,7 +242,12 @@ vfs_dcache_remove(struct v_dnode* dnode)
 
     llist_delete(&dnode->siblings);
     llist_delete(&dnode->aka_list);
-    hlist_delete(&dnode->hash_list);
+    lru_remove(dnode_lru, &dnode->lru);
+
+    cache_atomic_write(dnode_cache(dnode),
+    {
+        hlist_delete(&dnode->hash_list);
+    });
 
     dnode->parent = NULL;
     dnode->ref_count = 0;
@@ -200,10 +257,14 @@ void
 vfs_dcache_rehash(struct v_dnode* new_parent, struct v_dnode* dnode)
 {
     assert(new_parent);
+    assert(locked_node(new_parent));
 
-    hstr_rehash(&dnode->name, HSTR_FULL_HASH);
-    vfs_dcache_remove(dnode);
-    vfs_dcache_add(new_parent, dnode);
+    dnode_atomic(dnode, 
+    {
+        hstr_rehash(&dnode->name, HSTR_FULL_HASH);
+        vfs_dcache_remove(dnode);
+        vfs_dcache_add(new_parent, dnode);
+    });
 }
 
 int
@@ -250,6 +311,8 @@ vfs_open(struct v_dnode* dnode, struct v_file** file)
 void
 vfs_assign_inode(struct v_dnode* assign_to, struct v_inode* inode)
 {
+    lock_dnode(assign_to);
+
     if (assign_to->inode) {
         llist_delete(&assign_to->aka_list);
         assign_to->inode->link_count--;
@@ -258,26 +321,33 @@ vfs_assign_inode(struct v_dnode* assign_to, struct v_inode* inode)
     llist_append(&inode->aka_dnodes, &assign_to->aka_list);
     assign_to->inode = inode;
     inode->link_count++;
+
+    unlock_dnode(assign_to);
 }
 
 int
 vfs_link(struct v_dnode* to_link, struct v_dnode* name)
 {
     int errno;
+    struct v_inode* inode;
+
+    inode = to_link->inode;
 
     if ((errno = vfs_check_writable(to_link))) {
         return errno;
     }
 
-    lock_inode(to_link->inode);
+    lock_inode(inode);
+
     if (to_link->super_block->root != name->super_block->root) {
         errno = EXDEV;
-    } else if (!to_link->inode->ops->link) {
+    } else if (!inode->ops->link) {
         errno = ENOTSUP;
-    } else if (!(errno = to_link->inode->ops->link(to_link->inode, name))) {
-        vfs_assign_inode(name, to_link->inode);
+    } else if (!(errno = inode->ops->link(inode, name))) {
+        vfs_assign_inode(name, inode);
     }
-    unlock_inode(to_link->inode);
+
+    unlock_inode(inode);
 
     return errno;
 }
@@ -375,12 +445,22 @@ vfs_fsync(struct v_file* file)
 int
 vfs_alloc_fdslot(int* fd)
 {
+    struct v_fdtable* fdtab;
+
+    fdtab = __current->fdtable;
+    lock_fdtable(fdtab);
+
     for (size_t i = 0; i < VFS_MAX_FD; i++) {
-        if (!__current->fdtable->fds[i]) {
-            *fd = i;
-            return 0;
+        if (__current->fdtable->fds[i]) {
+            continue;
         }
+
+        *fd = i;
+        unlock_fdtable(fdtab);
+        return 0;
     }
+
+    unlock_fdtable(fdtab);
     return EMFILE;
 }
 
@@ -390,9 +470,9 @@ vfs_sb_alloc()
     struct v_superblock* sb = cake_grab(superblock_pile);
     memset(sb, 0, sizeof(*sb));
     llist_init_head(&sb->sb_list);
-    
-    sb->i_cache = vzalloc(VFS_HASHTABLE_SIZE * sizeof(struct hbucket));
-    sb->d_cache = vzalloc(VFS_HASHTABLE_SIZE * sizeof(struct hbucket));
+
+    vfs_vncache_init(&sb->i_cache);
+    vfs_vncache_init(&sb->d_cache);
 
     sb->ref_count = 1;
     return sb;
@@ -418,25 +498,36 @@ vfs_sb_unref(struct v_superblock* sb)
         sb->ops.release(sb);
     }
 
-    vfree(sb->i_cache);
-    vfree(sb->d_cache);
-    
+    vfs_vncache_free(&sb->i_cache);
+    vfs_vncache_free(&sb->d_cache);
+
     cake_release(superblock_pile, sb);
 }
 
-static int
+static inline bool
+__dnode_evictable(struct v_dnode* dnode)
+{
+    return dnode->ref_count == 1 
+        && llist_empty(&dnode->children);
+}
+
+static bool
 __vfs_try_evict_dnode(struct lru_node* obj)
 {
     struct v_dnode* dnode = container_of(obj, struct v_dnode, lru);
 
-    if (!dnode->ref_count) {
-        vfs_d_free(dnode);
-        return 1;
+    if (mutex_on_hold(&dnode->lock))
+        return false;
+
+    if (!__dnode_evictable(dnode)) {
+        return false;
     }
-    return 0;
+
+    vfs_d_free(dnode);
+    return true;
 }
 
-static int
+static bool
 __vfs_try_evict_inode(struct lru_node* obj)
 {
     struct v_inode* inode = container_of(obj, struct v_inode, lru);
@@ -484,13 +575,14 @@ void
 vfs_d_free(struct v_dnode* dnode)
 {
     assert(dnode->ref_count == 1);
-
+    
     if (dnode->inode) {
         assert(dnode->inode->link_count > 0);
         dnode->inode->link_count--;
     }
 
     vfs_dcache_remove(dnode);
+
     // Make sure the children de-referencing their parent.
     // With lru presented, the eviction will be propagated over the entire
     // detached subtree eventually
@@ -505,6 +597,7 @@ vfs_d_free(struct v_dnode* dnode)
     }
 
     vfs_sb_unref(dnode->super_block);
+    
     vfree((void*)dnode->name.value);
     cake_release(dnode_pile, dnode);
 }
@@ -512,26 +605,32 @@ vfs_d_free(struct v_dnode* dnode)
 struct v_inode*
 vfs_i_find(struct v_superblock* sb, u32_t i_id)
 {
-    struct hbucket* slot = &sb->i_cache[i_id & VFS_HASH_MASK];
-    struct v_inode *pos, *n;
-    hashtable_bucket_foreach(slot, pos, n, hash_list)
-    {
-        if (pos->id == i_id) {
-            lru_use_one(inode_lru, &pos->lru);
-            return pos;
-        }
-    }
+    struct hbucket* slot;
+    struct v_inode *pos, *n, *found = NULL;
 
-    return NULL;
+    cache_atomic_read(&sb->i_cache, 
+    {
+        slot = &sb->i_cache.pool[i_id & VFS_HASH_MASK];
+
+        hashtable_bucket_foreach(slot, pos, n, hash_list)
+        {
+            if (pos->id != i_id) {
+                continue;
+            }
+
+            lru_use_one(inode_lru, &pos->lru);
+            found = pos;
+            break;
+        }
+    });
+
+    return found;
 }
 
 void
 vfs_i_addhash(struct v_inode* inode)
 {
-    struct hbucket* slot = &inode->sb->i_cache[inode->id & VFS_HASH_MASK];
-
-    hlist_delete(&inode->hash_list);
-    hlist_add(&slot->head, &inode->hash_list);
+    vfs_vncache_add(inode_cache(inode), inode->id, &inode->hash_list);
 }
 
 struct v_inode*
@@ -560,6 +659,7 @@ vfs_i_alloc(struct v_superblock* sb)
 
     vfs_i_assign_sb(inode, sb);
     lru_use_one(inode_lru, &inode->lru);
+    
     return inode;
 }
 
@@ -570,6 +670,7 @@ vfs_i_free(struct v_inode* inode)
         pcache_release(inode->pg_cache);
         vfree(inode->pg_cache);
     }
+
     // we don't need to sync inode.
     // If an inode can be free, then it must be properly closed.
     // Hence it must be synced already!
@@ -578,7 +679,10 @@ vfs_i_free(struct v_inode* inode)
     }
 
     vfs_sb_unref(inode->sb);
+    
     hlist_delete(&inode->hash_list);
+    lru_remove(inode_lru, &inode->lru);
+
     cake_release(inode_pile, inode);
 }
 
@@ -596,10 +700,19 @@ vfs_i_free(struct v_inode* inode)
 int
 vfs_getfd(int fd, struct v_fd** fd_s)
 {
-    if (TEST_FD(fd) && (*fd_s = __current->fdtable->fds[fd])) {
-        return 0;
+    struct v_fdtable* fdtab;
+
+    if (!TEST_FD(fd)) {
+        return EBADF;
     }
-    return EBADF;
+
+    fdtab = __current->fdtable;
+
+    lock_fdtable(fdtab);
+    *fd_s = __current->fdtable->fds[fd];
+    unlock_fdtable(fdtab);
+
+    return !*fd_s ? EBADF : 0;
 }
 
 static int
@@ -869,6 +982,7 @@ __DEFINE_LXSYSCALL2(int, sys_readdir, int, fd, struct lx_dirent*, dent)
     if ((errno = fd_s->file->ops->readdir(fd_s->file, &dctx)) != 1) {
         goto unlock;
     }
+
     dent->d_offset++;
     fd_s->file->f_pos++;
 
@@ -1105,6 +1219,42 @@ vfs_get_dtype(int itype)
     return dtype;
 }
 
+struct v_fdtable*
+fdtable_create()
+{
+    struct v_fdtable* fdtab;
+
+    fdtab = vzalloc(sizeof(struct v_fdtable));
+    mutex_init(&fdtab->lock);
+
+    return fdtab;
+}
+
+void
+fdtable_copy(struct v_fdtable* dest, struct v_fdtable* src)
+{
+    lock_fdtable(dest);
+    lock_fdtable(src);
+    
+    for (size_t i = 0; i < VFS_MAX_FD; i++) {
+        struct v_fd* fd = src->fds[i];
+        if (!fd)
+            continue;
+        vfs_dup_fd(fd, &dest->fds[i]);
+    }
+
+    unlock_fdtable(dest);
+    unlock_fdtable(src);
+}
+
+void
+fdtable_free(struct v_fdtable* table)
+{
+    assert(!mutex_on_hold(&table->lock));
+
+    vfree(table);
+}
+
 __DEFINE_LXSYSCALL3(int, realpathat, int, fd, char*, buf, size_t, size)
 {
     int errno;
@@ -1114,11 +1264,12 @@ __DEFINE_LXSYSCALL3(int, realpathat, int, fd, char*, buf, size_t, size)
     }
 
     struct v_dnode* dnode;
-    errno = vfs_get_path(fd_s->file->dnode, buf, size, 0);
 
-    if (errno >= 0) {
-        return errno;
-    }
+    dnode = fd_s->file->dnode;
+
+    lock_dnode(dnode);
+    errno = vfs_get_path(dnode, buf, size, 0);
+    unlock_dnode(dnode);
 
 done:
     return DO_STATUS(errno);
@@ -1235,10 +1386,13 @@ done:
 
 __DEFINE_LXSYSCALL1(int, mkdir, const char*, path)
 {
-    int errno = 0;
+    int errno;
+    struct hstr name;
+    struct v_inode* inode;
     struct v_dnode *parent, *dir;
     char name_value[VFS_NAME_MAXLEN];
-    struct hstr name = HHSTR(name_value, 0, 0);
+
+    name = HHSTR(name_value, 0, 0);
 
     if ((errno = vfs_walk_proc(path, &parent, &name, VFS_WALK_PARENT))) {
         goto done;
@@ -1258,7 +1412,7 @@ __DEFINE_LXSYSCALL1(int, mkdir, const char*, path)
         goto done;
     }
 
-    struct v_inode* inode = parent->inode;
+    inode = parent->inode;
 
     lock_dnode(parent);
     lock_inode(inode);
@@ -1410,12 +1564,14 @@ vfs_dup_fd(struct v_fd* old, struct v_fd** new)
 int
 vfs_dup2(int oldfd, int newfd)
 {
+    int errno;
+    struct v_fdtable* fdtab;
+    struct v_fd *oldfd_s, *newfd_s;
+    
     if (newfd == oldfd) {
         return newfd;
     }
 
-    int errno;
-    struct v_fd *oldfd_s, *newfd_s;
     if ((errno = vfs_getfd(oldfd, &oldfd_s))) {
         goto done;
     }
@@ -1425,15 +1581,25 @@ vfs_dup2(int oldfd, int newfd)
         goto done;
     }
 
-    newfd_s = __current->fdtable->fds[newfd];
+    fdtab = __current->fdtable;
+    lock_fdtable(fdtab);
+
+    newfd_s = fdtab->fds[newfd];
     if (newfd_s && (errno = vfs_close(newfd_s->file))) {
-        goto done;
+        goto unlock_and_done;
     }
 
-    if (!(errno = vfs_dup_fd(oldfd_s, &newfd_s))) {
-        __current->fdtable->fds[newfd] = newfd_s;
-        return newfd;
+    if ((errno = vfs_dup_fd(oldfd_s, &newfd_s))) {
+        goto unlock_and_done;
     }
+
+    fdtab->fds[newfd] = newfd_s;
+    
+    unlock_fdtable(fdtab);
+    return newfd;
+
+unlock_and_done:
+    unlock_fdtable(fdtab);
 
 done:
     return DO_STATUS(errno);
@@ -1650,6 +1816,7 @@ vfs_do_rename(struct v_dnode* current, struct v_dnode* target)
 
     lock_dnode(current);
     lock_dnode(target);
+
     if (oldparent)
         lock_dnode(oldparent);
     if (newparent)
@@ -1678,6 +1845,7 @@ vfs_do_rename(struct v_dnode* current, struct v_dnode* target)
 
 cleanup:
     unlock_dnode(current);
+    
     if (oldparent)
         unlock_dnode(oldparent);
     if (newparent)

--- a/lunaix-os/kernel/process/fork.c
+++ b/lunaix-os/kernel/process/fork.c
@@ -45,18 +45,6 @@ region_maybe_cow(struct mm_region* region)
     tlb_flush_vmr_all(region);
 }
 
-static inline void
-__dup_fdtable(struct proc_info* pcb)
-{
-    for (size_t i = 0; i < VFS_MAX_FD; i++) {
-        struct v_fd* fd = __current->fdtable->fds[i];
-        if (!fd)
-            continue;
-        vfs_dup_fd(fd, &pcb->fdtable->fds[i]);
-    }
-}
-
-
 static void
 __dup_kernel_stack(struct thread* thread, ptr_t vm_mnt)
 {
@@ -172,7 +160,7 @@ dup_proc()
         vfs_ref_dnode(pcb->cwd);
     }
 
-    __dup_fdtable(pcb);
+    fdtable_copy(pcb->fdtable, __current->fdtable);
     uscope_copy(&pcb->uscope, current_user_scope());
 
     struct proc_mm* mm = vmspace(pcb);

--- a/lunaix-os/usr/LBuild
+++ b/lunaix-os/usr/LBuild
@@ -9,6 +9,8 @@ sources([
     "maze",
     "mkdir",
     "rm",
+    "testfork",
+    "fragfile",
 ])
 
 compile_opts([

--- a/lunaix-os/usr/fragfile.c
+++ b/lunaix-os/usr/fragfile.c
@@ -8,10 +8,14 @@ static char alphabets[] = "abcdefghijklmnopqrstuvwxyz"
                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                           "01234567890";
 
+#define NR_BUFSIZE   4096
+#define NR_NAME_LEN  8
+#define NR_REPEAT    5
+
 int main()
 {
-    unsigned int buf[4096];
-    char name[8];
+    unsigned int buf[NR_BUFSIZE];
+    char name[NR_NAME_LEN + 1];
     int fd = open("/dev/rand", O_RDONLY);
 
     if (mkdir("testdir") && errno != EEXIST)
@@ -26,25 +30,35 @@ int main()
         _exit(1);
     }
 
+    int nr_total = NR_REPEAT * NR_BUFSIZE / NR_NAME_LEN;
+
     int cnt = 0;
-    for (int i = 0; i < 1; i++)
+    for (int i = 0; i < NR_REPEAT; i++)
     {
         int n = read(fd, buf, 4096 * sizeof(int));
         int j = 0, k = 0;
         while (j < 4096) {
             name[k++] = alphabets[buf[j++] % 63];
 
-            if (k < 7) {
+            if (k < NR_NAME_LEN) {
                 continue;
             }
 
             k = 0;
             cnt++;
-            name[7] = 0;
+            name[NR_NAME_LEN] = 0;
 
-            printf("[%03d] creating: %s\n", cnt, name);
+            printf("[%04d/%04d] creating: %s\r", cnt, nr_total, name);
             int fd2 = open(name, O_RDONLY | O_CREAT);
-            if (fd2 < 0) {
+            
+            if (fd2 < 0) 
+            {
+                printf("\n");
+                if (errno == EDQUOT) {
+                    printf("Out of quota\n");
+                    return 0;
+                }
+
                 printf("Unable to open %d\n", errno);
                 continue;
             }
@@ -52,6 +66,6 @@ int main()
             close(fd2);
         }
     }
-    
+    printf("\n");
     return 0;
 }

--- a/lunaix-os/usr/fragfile.c
+++ b/lunaix-os/usr/fragfile.c
@@ -1,0 +1,57 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <lunaix/status.h>
+
+static char alphabets[] = "abcdefghijklmnopqrstuvwxyz"
+                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                          "01234567890";
+
+int main()
+{
+    unsigned int buf[4096];
+    char name[8];
+    int fd = open("/dev/rand", O_RDONLY);
+
+    if (mkdir("testdir") && errno != EEXIST)
+    {
+        printf("Unable to mkdir %d\n", errno);
+        _exit(1);
+    }
+
+    if (chdir("testdir"))
+    {
+        printf("Unable to chdir %d\n", errno);
+        _exit(1);
+    }
+
+    int cnt = 0;
+    for (int i = 0; i < 1; i++)
+    {
+        int n = read(fd, buf, 4096 * sizeof(int));
+        int j = 0, k = 0;
+        while (j < 4096) {
+            name[k++] = alphabets[buf[j++] % 63];
+
+            if (k < 7) {
+                continue;
+            }
+
+            k = 0;
+            cnt++;
+            name[7] = 0;
+
+            printf("[%03d] creating: %s\n", cnt, name);
+            int fd2 = open(name, O_RDONLY | O_CREAT);
+            if (fd2 < 0) {
+                printf("Unable to open %d\n", errno);
+                continue;
+            }
+
+            close(fd2);
+        }
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
```
This patch aims to identify potential race conditions in the current 
vfs implementation and propose correspond fixes.

Issues on directory entry insertions found in the ext2 file system 
also addressed in this patch for the sake of convenience.

```