### PR TITLE
Fix mke2fs arguments in mkrootfs

### DIFF
--- a/lunaix-os/scripts/mkrootfs
+++ b/lunaix-os/scripts/mkrootfs
@@ -51,7 +51,7 @@ function cleanup() {
 dd if=/dev/zero of="${rootfs}" count=${size_mb} bs=1M \
     || cleanup tmpmnt
 
-${prefix} mkfs.${fs} -L lunaix-rootfs -r 0 "${rootfs}" \
+${prefix} mkfs.${fs} -L lunaix-rootfs -E revision=0 "${rootfs}" \
     || cleanup tmpmnt img
 
 ${prefix} mount -o loop "${rootfs}" "${tmp_mnt}" \


### PR DESCRIPTION
The `-r` option has been removed in e2fsprogs.

```
mkfs.ext2: the -r option has been removed.

If you really need compatibility with pre-1995 Linux systems, use the
command-line option "-E revision=0".
```