### PR TITLE
Fix build error by adding -fno-stack-protector to CFLAGS in usr/LBuild

### DIFF
--- a/lunaix-os/usr/LBuild
+++ b/lunaix-os/usr/LBuild
@@ -15,6 +15,7 @@ src.c += (
 flag.cc += (
     "-ffreestanding",
     "-fno-pie",
+    "-fno-stack-protector",
     "-Werror"
 )
 


### PR DESCRIPTION
This pull request adds `-fno-stack-protector` to CFLAGS in `usr/LBuild` to fix build error.