### PR TITLE
Incorrect semantic meaning of bcache_free causing undefined behaviour

### DIFF
--- a/lunaix-os/includes/lunaix/bcache.h
+++ b/lunaix-os/includes/lunaix/bcache.h
@@ -147,7 +147,7 @@ void
 bcache_flush(struct bcache* cache);
 
 void
-bcache_free(struct bcache* cache);
+bcache_destory(struct bcache* cache);
 
 void
 bcache_zone_free(bcache_zone_t zone);

--- a/lunaix-os/kernel/bcache.c
+++ b/lunaix-os/kernel/bcache.c
@@ -196,7 +196,7 @@ bcache_flush(struct bcache* cache)
 }
 
 void
-bcache_free(struct bcache* cache)
+bcache_destory(struct bcache* cache)
 {
     lock(cache);
     
@@ -204,8 +204,6 @@ bcache_free(struct bcache* cache)
     btrie_release(&cache->root);
 
     unlock(cache);
-
-    vfree(cache);
 }
 
 void

--- a/lunaix-os/kernel/block/blkbuf.c
+++ b/lunaix-os/kernel/block/blkbuf.c
@@ -1,3 +1,4 @@
+#include "lunaix/bcache.h"
 #include <lunaix/blkbuf.h>
 #include <lunaix/mm/cake.h>
 #include <lunaix/mm/valloc.h>
@@ -234,7 +235,7 @@ blkbuf_syncall(struct blkbuf_cache* bc, bool async)
 void
 blkbuf_release(struct blkbuf_cache* bc)
 {
-    bcache_free(&bc->cached);
+    bcache_destory(&bc->cached);
     vfree(bc);
 }
 

--- a/lunaix-os/kernel/block/blkbuf.c
+++ b/lunaix-os/kernel/block/blkbuf.c
@@ -1,4 +1,3 @@
-#include "lunaix/bcache.h"
 #include <lunaix/blkbuf.h>
 #include <lunaix/mm/cake.h>
 #include <lunaix/mm/valloc.h>

--- a/lunaix-os/kernel/fs/pcache.c
+++ b/lunaix-os/kernel/fs/pcache.c
@@ -243,7 +243,7 @@ pcache_read(struct v_inode* inode, void* data, u32_t len, u32_t fpos)
 void
 pcache_release(struct pcache* pcache)
 {
-    bcache_free(&pcache->cache);
+    bcache_destory(&pcache->cache);
 }
 
 int


### PR DESCRIPTION
The `bcache_free` semantic pose a strong meaning do explicit freeing the bcache object itself while the bcache is designed to be embedded in another object. And a `vfree` statement was incorrectly smuggled into it due to such confusion.

This patch changes the `bcache_free` to `bcache_destory` and remove the vfree that could cause double free or other undefined behaviour.